### PR TITLE
Allow slices in templates.

### DIFF
--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -39,6 +39,21 @@ fn test_hello_args_two() {
 }
 
 #[test]
+fn test_list() {
+    assert_eq!(r2s(|o| list(o, &["foo", "bar"])),
+               "<ul>\n  <li>foo</li>\n  <li>bar</li>\n  \n</ul>\n");
+}
+
+#[test]
+fn test_uselist() {
+    assert_eq!(r2s(|o| uselist(o)),
+               "<h1>Two items</h1>\n\
+                <ul>\n  <li>foo</li>\n  <li>bar</li>\n  \n</ul>\n\n\
+                <h2>No items</h2>\n\
+                <ul>\n  \n</ul>\n\n");
+}
+
+#[test]
 fn test_hello_utf8() {
     assert_eq!(r2s(|o| hello_utf8(o, "δ", "ε", "δ < ε", "δ &lt; ε")),
                "<p>δ &lt; ε</p>\n\

--- a/examples/simple/templates/list.rs.html
+++ b/examples/simple/templates/list.rs.html
@@ -1,0 +1,7 @@
+@(items: &[&str])
+
+<ul>
+  @for item in items {
+    <li>@item</li>
+  }
+</ul>

--- a/examples/simple/templates/uselist.rs.html
+++ b/examples/simple/templates/uselist.rs.html
@@ -1,0 +1,8 @@
+@use templates::list;
+
+@()
+
+<h1>Two items</h1>
+@:list(&["foo", "bar"])
+<h2>No items</h2>
+@:list(&[])


### PR DESCRIPTION
When calling a sub-template that takes a slice as an argument, it is often reasonable to use a slice expression such as `&[foo, bar]`, `&["one", "two", "three"]`, or `&[]`.