### PR TITLE
Attempt better error reporting.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 base64 = "^0.3"
+lazy_static = "^0.2"
 md5 = "^0.3"
 nom = { version = "^2", features = ["verbose-errors"] }

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -41,16 +41,16 @@ fn test_hello_args_two() {
 #[test]
 fn test_list() {
     assert_eq!(r2s(|o| list(o, &["foo", "bar"])),
-               "<ul>\n  <li>foo</li>\n  <li>bar</li>\n  \n</ul>\n");
+               "<ul>\n  <li>foo</li>\n  <li>bar</li>\n  </ul>\n");
 }
 
 #[test]
 fn test_uselist() {
     assert_eq!(r2s(|o| uselist(o)),
                "<h1>Two items</h1>\n\
-                <ul>\n  <li>foo</li>\n  <li>bar</li>\n  \n</ul>\n\n\
+                <ul>\n  <li>foo</li>\n  <li>bar</li>\n  </ul>\n\n\
                 <h2>No items</h2>\n\
-                <ul>\n  \n</ul>\n\n");
+                <ul>\n  </ul>\n\n");
 }
 
 #[test]
@@ -114,7 +114,7 @@ fn test_hello_code() {
 #[test]
 fn test_for_loop() {
     assert_eq!(r2s(|o| for_loop(o, &vec!["Hello", "World"])),
-               "<h1>Looped paragraphs</h1>\n<p>Hello</p>\n<p>World</p>\n\n");
+               "<h1>Looped paragraphs</h1>\n<p>Hello</p>\n<p>World</p>\n");
 }
 
 #[test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,31 @@
+use nom::ErrorKind;
+use std::sync::Mutex;
+
+macro_rules! err_str(
+    ($msg:expr) => {{
+        use nom::ErrorKind;
+        use errors::def_error;
+        lazy_static! {
+            static ref ERR: ErrorKind = def_error($msg);
+        }
+        ERR.clone()
+    }}
+);
+
+pub fn def_error(msg: &'static str) -> ErrorKind {
+    let mut errors = ERRORS.lock().unwrap();
+    let n = errors.len();
+    errors.push(msg);
+    ErrorKind::Custom(n as u32)
+}
+
+pub fn get_error(n: u32) -> Option<String> {
+    match ERRORS.lock() {
+        Ok(e) => e.get(n as usize).map(|s| s.to_string()),
+        Err(_) => None,
+    }
+}
+
+lazy_static! {
+    static ref ERRORS: Mutex<Vec<&'static str>> = Mutex::new(Vec::new());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ extern crate nom;
 
 mod spacelike;
 mod expression;
+#[macro_use]
 mod templateexpression;
 mod template;
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,4 +1,3 @@
-use nom::ErrorKind;
 use spacelike::spacelike;
 use std::io::{self, Write};
 use std::str::from_utf8;
@@ -58,9 +57,7 @@ named!(pub template<&[u8], Template>,
            args: separated_list!(tag!(", "), formal_argument) >>
            tag!(")") >>
            spacelike >>
-           body: add_return_error!(
-               ErrorKind::Custom(1),
-               my_many_till!(template_expression, end_of_file)) >>
+           body: my_many_till!(template_expression, end_of_file) >>
            (Template { preamble: preamble, args: args, body: body.0 })
            ));
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -60,12 +60,12 @@ named!(pub template<&[u8], Template>,
            spacelike >>
            body: add_return_error!(
                ErrorKind::Custom(1),
-               many_till!(template_expression, end)) >>
+               many_till!(template_expression, end_of_file)) >>
            (Template { preamble: preamble, args: args, body: body.0 })
            ));
 
-named!(end<&[u8], ()>,
-       map!(eof!(), |_| ()));
+named!(end_of_file<&[u8], ()>,
+       value!((), eof!()));
 
 // TODO Actually parse arguments!
 named!(formal_argument<&[u8], String>,

--- a/src/template.rs
+++ b/src/template.rs
@@ -60,7 +60,7 @@ named!(pub template<&[u8], Template>,
            spacelike >>
            body: add_return_error!(
                ErrorKind::Custom(1),
-               many_till!(template_expression, end_of_file)) >>
+               my_many_till!(template_expression, end_of_file)) >>
            (Template { preamble: preamble, args: args, body: body.0 })
            ));
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -57,7 +57,11 @@ named!(pub template<&[u8], Template>,
            args: separated_list!(tag!(", "), formal_argument) >>
            tag!(")") >>
            spacelike >>
-           body: my_many_till!(template_expression, end_of_file) >>
+           body: my_many_till!(
+               return_error!(
+                   err_str!("Error in expression starting here:"),
+                   template_expression),
+               call!(end_of_file)) >>
            (Template { preamble: preamble, args: args, body: body.0 })
            ));
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,3 +1,4 @@
+use nom::ErrorKind;
 use spacelike::spacelike;
 use std::io::{self, Write};
 use std::str::from_utf8;
@@ -57,10 +58,14 @@ named!(pub template<&[u8], Template>,
            args: separated_list!(tag!(", "), formal_argument) >>
            tag!(")") >>
            spacelike >>
-           body: many0!(template_expression) >>
-           eof!() >>
-           (Template { preamble: preamble, args: args, body: body })
+           body: add_return_error!(
+               ErrorKind::Custom(1),
+               many_till!(template_expression, end)) >>
+           (Template { preamble: preamble, args: args, body: body.0 })
            ));
+
+named!(end<&[u8], ()>,
+       map!(eof!(), |_| ()));
 
 // TODO Actually parse arguments!
 named!(formal_argument<&[u8], String>,

--- a/src/templateexpression.rs
+++ b/src/templateexpression.rs
@@ -177,7 +177,7 @@ named!(pub template_expression<&[u8], TemplateExpression>,
                    text: "}}".to_string()
                }) |
                Some(b"if") => return_error!(
-                   err_str!("Error in conditional expression"),
+                   err_str!("Error in conditional expression:"),
                    do_parse!(
                    spacelike >>
                    expr: cond_expression >> spacelike >>
@@ -201,7 +201,7 @@ named!(pub template_expression<&[u8], TemplateExpression>,
                    expr: return_error!(err_str!("Expected iterable expression"),
                                        expression) >>
                    spacelike >>
-                   body: return_error!(err_str!("Error in loop block"),
+                   body: return_error!(err_str!("Error in loop block:"),
                                        template_block) >> spacelike >>
                    (TemplateExpression::ForLoop {
                        name: name,
@@ -222,11 +222,12 @@ named!(pub template_expression<&[u8], TemplateExpression>,
 named!(template_block<&[u8], Vec<TemplateExpression>>,
        do_parse!(return_error!(err_str!("Expected \"{\""), char!('{')) >>
                  spacelike >>
-                 body: my_many_till!(template_expression, block_end) >>
+                 body: my_many_till!(
+                     return_error!(
+                         err_str!("Error in expression starting here:"),
+                         template_expression),
+                     char!('}')) >>
                  (body.0)));
-
-named!(block_end<&[u8], ()>,
-       value!((), tag!("}")));
 
 named!(template_argument<&[u8], TemplateArgument>,
        alt!(map!(delimited!(tag!("{"), many0!(template_expression), tag!("}")),

--- a/src/templateexpression.rs
+++ b/src/templateexpression.rs
@@ -9,7 +9,8 @@ use std::str::from_utf8;
 /// This should be removed when a fix for that is released from nom.
 #[macro_export]
 macro_rules! my_many_till(
-  ($i:expr, $submac1:ident!( $($args1:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
+  ($i:expr, $submac1:ident!( $($args1:tt)* ), $submac2:ident!( $($args2:tt)* ))
+        => (
     {
       use nom::InputLength;
       use nom::ErrorKind;
@@ -29,7 +30,9 @@ macro_rules! my_many_till(
           _                           => {
             match $submac1!(input, $($args1)*) {
               IResult::Error(err)                            => {
-                ret = IResult::Error(error_node_position!(ErrorKind::ManyTill,input, err));
+                ret = IResult::Error(error_node_position!(ErrorKind::ManyTill,
+                                                          input,
+                                                          err));
                 break;
               },
               IResult::Incomplete(Needed::Unknown) => {
@@ -44,7 +47,8 @@ macro_rules! my_many_till(
               IResult::Done(i, o)                          => {
                 // loop trip must always consume (otherwise infinite loops)
                 if i == input {
-                  ret = IResult::Error(error_position!(ErrorKind::ManyTill,input));
+                  ret = IResult::Error(error_position!(ErrorKind::ManyTill,
+                                                       input));
                   break;
                 }
 

--- a/src/templateexpression.rs
+++ b/src/templateexpression.rs
@@ -261,8 +261,10 @@ mod test {
                        Box::new(Err::NodePosition(
                            ErrorKind::Switch, &t[..],
                            Box::new(Err::NodePosition(
-                               ErrorKind::Custom(7), &t[4..],
-                               Box::new(Err::Position(
-                                   ErrorKind::Alt, &t[4..])))))))))
+                               ErrorKind::Custom(4), &t[4..],
+                               Box::new(Err::NodePosition(
+                                   ErrorKind::Custom(7), &t[4..],
+                                   Box::new(Err::Position(
+                                       ErrorKind::Alt, &t[4..])))))))))))
     }
 }

--- a/src/templateexpression.rs
+++ b/src/templateexpression.rs
@@ -248,28 +248,34 @@ named!(cond_expression<&[u8], String>,
                       (format!("let {} = {}", lhs, rhs))) |
             expression));
 
-/* TODO Implement a sane way to test for error messages!
 #[cfg(test)]
 mod test {
     use super::*;
-    use nom::ErrorKind;
-    use nom::IResult::Error;
-    use nom::verbose_errors::Err;
+    use super::super::show_errors;
 
     #[test]
     fn if_missing_conditional() {
-        let t = b"@if { oops }";
-        assert_eq!(template_expression(t),
-                   Error(Err::NodePosition(
-                       ERR_TE.clone(), &t[..],
-                       Box::new(Err::NodePosition(
-                           ErrorKind::Switch, &t[..],
-                           Box::new(Err::NodePosition(
-                               ERR_IF.clone(), &t[4..],
-                               Box::new(Err::NodePosition(
-                                   ErrorKind::Custom(7), &t[4..],
-                                   Box::new(Err::Position(
-                                       ErrorKind::Alt, &t[4..])))))))))))
+        // TODO The actual message here should be improved.
+        assert_eq!(expression_error(b"@if { oops }"),
+                   ":   1:@if { oops }\n\
+                    :         ^ Error in conditional expression:\n\
+                    :   1:@if { oops }\n\
+                    :         ^ Alt\n")
+    }
+
+    #[test]
+    fn for_missig_in() {
+        // TODO The second part of this message isn't really helpful.
+        assert_eq!(expression_error(b"@for what ever { hello }"),
+                   ":   1:@for what ever { hello }\n\
+                    :               ^ Expected \"in\"\n\
+                    :   1:@for what ever { hello }\n\
+                    :               ^ Tag\n")
+    }
+
+    fn expression_error(input: &[u8]) -> String {
+        let mut buf = Vec::new();
+        show_errors(&mut buf, input, template_expression(input), ":");
+        String::from_utf8(buf).unwrap()
     }
 }
-*/


### PR DESCRIPTION
Messages for parse error in templates needs to be improved.  This is an attempt to fix issue #8 .

- [x] Implement a small proof of concept that errors _can_ be handled better.
- [x] Actually get error messages through a repeating parser (such as `many0!` or `many_till!`). (using a local `my_many_till!` until Geal/nom#463 is resolved).
- [x] Implement user-friendly printing of error messages.
- [x] Mark potential error points in the parser to return `Custom` errors, and write nice messages for them.

The messages for individual errors can of course be improved, but I think I've laid a solid base for how to handle them here.