### PR TITLE
Allow destructure in loops.

### DIFF
--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -46,6 +46,13 @@ fn test_list() {
 }
 
 #[test]
+fn test_list_destructure() {
+    assert_eq!(r2s(|o| list_destructure(o, &["foo", "bar"])),
+               "<ul>\n  \n    <li>0: foo</li>\n  \n    \
+                <li>1: bar</li>\n  </ul>\n");
+}
+
+#[test]
 fn test_uselist() {
     assert_eq!(r2s(|o| uselist(o)),
                "<h1>Two items</h1>\n\

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -53,6 +53,13 @@ fn test_list_destructure() {
 }
 
 #[test]
+fn test_list_destructure_2() {
+    assert_eq!(r2s(|o| list_destructure_2(o)),
+               "\n    <p>Rasmus is 44 years old.</p>\n\n    \
+                <p>Mike is 36 years old.</p>\n");
+}
+
+#[test]
 fn test_uselist() {
     assert_eq!(r2s(|o| uselist(o)),
                "<h1>Two items</h1>\n\

--- a/examples/simple/templates/list_destructure.rs.html
+++ b/examples/simple/templates/list_destructure.rs.html
@@ -1,0 +1,7 @@
+@(items: &[&str])
+
+<ul>
+  @for (n, item) in items.iter().enumerate() {
+    <li>@n: @item</li>
+  }
+</ul>

--- a/examples/simple/templates/list_destructure_2.rs.html
+++ b/examples/simple/templates/list_destructure_2.rs.html
@@ -1,0 +1,5 @@
+@()
+
+@for &(name, age) in &[("Rasmus", 44), ("Mike", 36)] {
+    <p>@name is @age years old.</p>
+}

--- a/src/Template_syntax.rs
+++ b/src/Template_syntax.rs
@@ -84,6 +84,15 @@ pub mod b_Loops {
     //!     <p>@n: @item</p>
     //! }
     //! ```
+    //!
+    //! It is also possible to loop over a literal array (which may be
+    //! an array of tuples), as long as you do it by reference:
+    //!
+    //! ```text
+    //! @for &(name, age) in &[("Rasmus", 44), ("Mike", 36)] {
+    //!     <p>@name is @age years old.</p>
+    //! }
+    //! ```
 }
 
 pub mod c_Conditionals {

--- a/src/Template_syntax.rs
+++ b/src/Template_syntax.rs
@@ -74,6 +74,16 @@ pub mod b_Loops {
     //!
     //! Note that the thing to loop over (items, in the example) is a rust
     //! expression, while the contents of the block is template code.
+    //!
+    //! If items is a slice of tuples (or really, anything that is
+    //! iterable yielding tuples), it is possible to deconstruct the
+    //! tuples into separate values directly:
+    //!
+    //! ```text
+    //! @for (n, item) in items.iter().enumerate() {
+    //!     <p>@n: @item</p>
+    //! }
+    //! ```
 }
 
 pub mod c_Conditionals {

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -39,7 +39,7 @@ named!(pub expression<&[u8], String>,
                }) >>
            (format!("{}{}{}", from_utf8(pre).unwrap(), name, post))));
 
-named!(comma_expressions<&[u8], String>,
+named!(pub comma_expressions<&[u8], String>,
        map!(separated_list!(tag!(", "), expression),
             |list: Vec<_>| list.join(", ")));
 

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -13,6 +13,9 @@ named!(pub expression<&[u8], String>,
                                 char!('"') >>
                                 (format!("\"{}\"",
                                          from_utf8(text).unwrap()))) |
+                      do_parse!(tag!("(") >> args: comma_expressions >>
+                                tag!(")") >>
+                                (format!("({})", args))) |
                       do_parse!(tag!("[") >> args: comma_expressions >>
                                 tag!("]") >>
                                 (format!("[{}]", args))))) >>

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -141,10 +141,10 @@ mod test {
     }
     #[test]
     fn non_expression_c() {
-        assert_eq!(expression_error_message(b"()"),
-                   ":   1:()\n\
+        assert_eq!(expression_error_message(b"(+)"),
+                   ":   1:(+)\n\
                     :     ^ Expected rust expression\n\
-                    :   1:()\n\
+                    :   1:(+)\n\
                     :     ^ Alt\n");
     }
     fn expression_error_message(input: &[u8]) -> String {

--- a/src/templateexpression.rs
+++ b/src/templateexpression.rs
@@ -188,14 +188,18 @@ named!(pub template_expression<&[u8], TemplateExpression>,
                    }))) |
                Some(b"for") => do_parse!(
                    spacelike >>
-                   name: return_error!(err_str!("Expected loop variable name \
-                                                 or destructuring tuple"),
-                                       alt!(rust_name |
-                                            do_parse!(tag!("(") >>
-                                                      args: comma_expressions >>
-                                                      tag!(")") >>
-                                                      (format!("({})", args)))
-                                            )) >>
+                   name: return_error!(
+                       err_str!("Expected loop variable name \
+                                 or destructuring tuple"),
+                       alt!(rust_name |
+                            do_parse!(pre: opt!(char!('&')) >>
+                                      tag!("(") >>
+                                      args: comma_expressions >>
+                                      tag!(")") >>
+                                      (format!("{}({})",
+                                               pre.unwrap_or(' '),
+                                               args)))
+                            )) >>
                    spacelike >>
                    return_error!(err_str!("Expected \"in\""), tag!("in")) >>
                    spacelike >>

--- a/src/templateexpression.rs
+++ b/src/templateexpression.rs
@@ -1,4 +1,4 @@
-use expression::{expression, rust_name};
+use expression::{comma_expressions, expression, rust_name};
 use spacelike::{comment, spacelike};
 use std::fmt::{self, Display};
 use std::str::from_utf8;
@@ -188,8 +188,14 @@ named!(pub template_expression<&[u8], TemplateExpression>,
                    }))) |
                Some(b"for") => do_parse!(
                    spacelike >>
-                   name: return_error!(err_str!("Expected loop variable name"),
-                                       rust_name) >>
+                   name: return_error!(err_str!("Expected loop variable name \
+                                                 or destructuring tuple"),
+                                       alt!(rust_name |
+                                            do_parse!(tag!("(") >>
+                                                      args: comma_expressions >>
+                                                      tag!(")") >>
+                                                      (format!("({})", args)))
+                                            )) >>
                    spacelike >>
                    return_error!(err_str!("Expected \"in\""), tag!("in")) >>
                    spacelike >>


### PR DESCRIPTION
When looping over an iterable of tuples, it should be possible to destructure the tuple into individual variables directly in the loop construct.

Suggested by @nubis in #14.