### PR TITLE
Allow complex argument types to templats

### DIFF
--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -40,6 +40,23 @@ fn test_hello_args_two() {
 }
 
 #[test]
+fn test_if_let_some() {
+    assert_eq!(r2s(|o| if_let(o, Some("thing"))),
+               "<p> The item is thing </p>\n")
+}
+#[test]
+fn test_if_let_none() {
+    assert_eq!(r2s(|o| if_let(o, None)),
+               "<p> Got nothing </p>\n")
+}
+
+#[test]
+fn test_if_let_destructure() {
+    assert_eq!(r2s(|o| if_let_destructure(o, Some((47, 11)))),
+               "<p> We have 47 and 11 </p>\n")
+}
+
+#[test]
 fn test_list() {
     assert_eq!(r2s(|o| list(o, &["foo", "bar"])),
                "<ul>\n  \n    <li>foo</li>\n  \n    <li>bar</li>\n  </ul>\n");

--- a/examples/simple/templates/if_let.rs.html
+++ b/examples/simple/templates/if_let.rs.html
@@ -1,0 +1,3 @@
+@(item: Option<&str>)
+
+<p>@if let Some(item) = item { The item is @item } else { Got nothing }</p>

--- a/examples/simple/templates/if_let_destructure.rs.html
+++ b/examples/simple/templates/if_let_destructure.rs.html
@@ -1,0 +1,3 @@
+@(item: Option<(u32, u32)>)
+
+<p>@if let Some((a, b)) = item { We have @a and @b } else { Got nothing }</p>

--- a/src/Template_syntax.rs
+++ b/src/Template_syntax.rs
@@ -196,7 +196,3 @@ pub mod d_Calling_other_templates {
     //! })
     //! ```
 }
-#[cfg(doc_test)]
-pub fn test_template(code: &str) {
-    // ok
-}

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,8 +1,8 @@
+use expression::rust_name;
 use spacelike::spacelike;
 use std::io::{self, Write};
 use std::str::from_utf8;
 use templateexpression::{TemplateExpression, template_expression};
-use expression::rust_name;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Template {
@@ -81,12 +81,14 @@ named!(type_expression<&[u8], ()>,
            alt!(tag!("&") | tag!("")) >>
            return_error!(err_str!("Expected rust type expression"),
                          alt!(map!(rust_name, |_| ()) |
-                              do_parse!(tag!("[") >> type_expression >> tag!("]") >>
+                              do_parse!(tag!("[") >> type_expression >>
+                                        tag!("]") >>
                                         ()) |
                               do_parse!(tag!("(") >> comma_type_expressions >>
                                         tag!(")") >>
                                         ()))) >>
-           opt!(do_parse!(tag!("<") >> comma_type_expressions >> tag!(">") >> ())) >>
+           opt!(do_parse!(tag!("<") >> comma_type_expressions >> tag!(">") >>
+                          ())) >>
            ()));
 
 named!(pub comma_type_expressions<&[u8], ()>,


### PR DESCRIPTION
Complex argument types to templates wasn't parsed properly.  Instead, the argument list was simply terminated on the first `)` found, which broke for types containing parenthesis, e.g. `Option<(u8, u8)>`.

I discovered this when trying to add examples of `@if let` matching, related to #14 .