### PR TITLE
Allow much more in parentehsis expressions.

### DIFF
--- a/src/Template_syntax.rs
+++ b/src/Template_syntax.rs
@@ -55,6 +55,24 @@ pub mod a_Value_expressions {
     //! ```text
     //! <p>The value is @format!("{:.1}", float_value).</p>
     //! ```
+    //!
+    //! If more complex expressions are needed, they can be put in
+    //! parenthesis.
+    //!
+    //! ```text
+    //! <p>The sum @a+3 is @(a+3).</p>
+    //! ```
+    //!
+    //! Anything is allowed in parenthesis, as long as parenthesis,
+    //! brackets and string quotes are balanced.
+    //! Note that this also applies to the parenthesis of a function
+    //! call or the brackets of an index, so complex things like the
+    //! following are allowed:
+    //!
+    //! ```text
+    //! <p>Index: @myvec[t.map(|s| s.length()).unwrap_or(0)].</p>
+    //! <p>Argument: @call(a + 3, |t| t.something()).</p>
+    //! ```
 }
 
 pub mod b_Loops {

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -3,9 +3,7 @@ use std::str::from_utf8;
 
 named!(pub expression<&[u8], String>,
        do_parse!(
-           pre: map_res!(alt!(tag!("&") | tag!("!") | tag!("*") | tag!("ref ") |
-                              tag!("")),
-                        from_utf8) >>
+           pre: map_res!(alt!(tag!("&") | tag!("*") | tag!("")), from_utf8) >>
            name: return_error!(err_str!("Expected rust expression"),
                                alt_complete!(rust_name |
                                              map_res!(digit, from_utf8) |
@@ -133,7 +131,7 @@ mod test {
     }
     #[test]
     fn expression_6() {
-        check_expr("!foo.is_empty()");
+        check_expr("(!foo.is_empty())");
     }
     #[test]
     fn expression_7() {

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -7,12 +7,11 @@ named!(pub expression<&[u8], String>,
                               tag!("")),
                         from_utf8) >>
            name: return_error!(err_str!("Expected rust expression"),
-                              alt_complete!(map!(rust_name, String::from) |
-                      map!(map_res!(digit, from_utf8), String::from) |
-                      map!(quoted_string, String::from) |
-                      map!(expr_in_parens, String::from) |
-                      map!(delimited!(tag!("["), comma_expressions, tag!("]")),
-                           |expr| format!("[{}]", expr)))) >>
+                               alt_complete!(rust_name |
+                                             map_res!(digit, from_utf8) |
+                                             quoted_string |
+                                             expr_in_parens |
+                                             expr_in_brackets)) >>
            post: fold_many0!(
                alt_complete!(
                    map!(preceded!(tag!("."), expression),
@@ -20,12 +19,11 @@ named!(pub expression<&[u8], String>,
                    map!(preceded!(tag!("::"), expression),
                         |expr| format!("::{}", expr)) |
                    map!(expr_in_parens, String::from) |
-                   map!(delimited!(tag!("["), comma_expressions, tag!("]")),
-                        |expr| format!("[{}]", expr)) |
+                   map!(expr_in_brackets, String::from) |
                    map!(preceded!(tag!("!"), expr_in_parens),
                         |expr| format!("!{}", expr)) |
-                   map!(delimited!(tag!("!["), comma_expressions, tag!("]")),
-                        |expr| format!("![{}]", expr))),
+                   map!(preceded!(tag!("!"), expr_in_brackets),
+                        |expr| format!("!{}", expr))),
                String::new(),
                |mut acc: String, item: String| {
                    acc.push_str(&item);
@@ -49,11 +47,12 @@ named!(
 
 named!(
     expr_in_parens<&[u8], &str>,
-    map_res!(recognize!(
-        delimited!(
+    map_res!(
+        recognize!(delimited!(
             tag!("("),
             many0!(alt!(
-                value!((), is_not!("()\"/")) |
+                value!((), is_not!("[]()\"/")) |
+                value!((), expr_in_brackets) |
                 value!((), expr_in_parens) |
                 value!((), quoted_string) |
                 value!((), rust_comment) |
@@ -66,14 +65,33 @@ named!(
 );
 
 named!(
-    quoted_string<&[u8], String>,
-    map!(delimited!(char!('"'),
-               map_res!(
-                   escaped!(is_not!("\"\\"),
-                            '\\', one_of!("\"\\")),
-                   from_utf8),
-               char!('"')),
-    |text| format!("\"{}\"", text)
+    expr_in_brackets<&[u8], &str>,
+    map_res!(
+        recognize!(delimited!(
+            tag!("["),
+            many0!(alt!(
+                value!((), is_not!("[]()\"/")) |
+                value!((), expr_in_brackets) |
+                value!((), expr_in_parens) |
+                value!((), quoted_string) |
+                value!((), rust_comment) |
+                value!((), terminated!(tag!("/"), none_of!("*")))
+            )),
+            tag!("]")
+        )),
+        from_utf8
+    )
+);
+
+named!(
+    quoted_string<&[u8], &str>,
+    map_res!(
+        recognize!(delimited!(
+            char!('"'),
+            escaped!(is_not!("\"\\"), '\\', one_of!("\"\\")),
+            char!('"')
+        )),
+        from_utf8
     )
 );
 

--- a/src/templateexpression.rs
+++ b/src/templateexpression.rs
@@ -354,7 +354,7 @@ mod test {
     #[test]
     fn if_let_2() {
         assert_eq!(
-            template_expression(b"@if let Some((x,y)) = x { something }"),
+            template_expression(b"@if let Some((x, y)) = x { something }"),
             IResult::Done(
                 &b""[..],
                 TemplateExpression::IfBlock {

--- a/src/templateexpression.rs
+++ b/src/templateexpression.rs
@@ -239,12 +239,12 @@ named!(
                         spacelike)),
                 |(name, expr, body)| TemplateExpression::ForLoop {
                     name,
-                    expr,
+                    expr: expr.to_string(),
                     body,
                 }) |
             Some(b"") => map!(
                 expression,
-                |expr| TemplateExpression::Expression{ expr }
+                |expr| TemplateExpression::Expression{ expr: expr.to_string() }
             ) |
             None => alt!(
                 map!(comment, |()| TemplateExpression::Comment) |
@@ -271,7 +271,7 @@ named!(template_block<&[u8], Vec<TemplateExpression>>,
 named!(template_argument<&[u8], TemplateArgument>,
        alt!(map!(delimited!(tag!("{"), many0!(template_expression), tag!("}")),
                  TemplateArgument::Body) |
-            map!(expression, TemplateArgument::Rust)));
+            map!(map!(expression, String::from), TemplateArgument::Rust)));
 
 named!(
     cond_expression<&[u8], String>,
@@ -299,7 +299,7 @@ named!(
             |(a, b)| if let Some((op, rhs)) = b {
                 format!("{} {} {}", a, op, rhs)
             } else {
-                a
+                a.to_string()
             })
     )
 );


### PR DESCRIPTION
Basically, just handle nesting parenthesis, comments, and strings, and let the rust compiler sort everything else out in the generated code.

Attempts to implement @kornelski s suggestion from #25 .