### PR TITLE
Allow older Clippy syntax

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -553,6 +553,7 @@ fn handle_entries(
                     f.write_all(
                         b"#[cfg_attr(feature=\"cargo-clippy\", \
                           allow(useless_attribute))]\n\
+                          #[allow(renamed_and_removed_lints)]\n\
                           #[allow(unused)]\n\
                           use super::{Html,ToHtml};\n",
                     )?;

--- a/src/template.rs
+++ b/src/template.rs
@@ -18,6 +18,7 @@ impl Template {
             b"use std::io::{self, Write};\n\
              #[cfg_attr(feature=\"cargo-clippy\", \
              allow(useless_attribute))]\n\
+             #[allow(renamed_and_removed_lints)]\n\
              #[allow(unused)]\n\
              use super::{Html,ToHtml};\n",
         )?;


### PR DESCRIPTION
Clippy's syntax is changing, and nightly started warning about it. This silences the warning.