### PR TITLE
6-9× faster escaping

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,108 @@
+#![feature(test)]
+extern crate ructe;
+extern crate test;
+use std::fmt::Display;
+use std::io;
+use std::io::Write;
+use test::Bencher;
+
+include!("../src/template_utils.rs");
+
+#[bench]
+fn raw(b: &mut Bencher) {
+    b.iter(|| {
+        let mut buf = Vec::with_capacity(10000);
+        raw_inner(&mut buf);
+        buf
+    });
+}
+
+/// real template is a function that takes `dyn Write`, so non-inlineable
+/// function should simulate that instead of allowing optimizer to specialize for `Vec`
+#[inline(never)]
+fn raw_inner(buf: &mut dyn Write) {
+    // inner loop to stress escaping more than buffer allocation
+    for _ in 0..1000 {
+        let h = Html("Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod");
+        h.to_html(buf).unwrap();
+    }
+}
+
+#[bench]
+fn escaped_no_op(b: &mut Bencher) {
+    b.iter(|| {
+        let mut buf = Vec::with_capacity(10000);
+        escaped_no_op_inner(&mut buf);
+        buf
+    });
+}
+
+#[inline(never)]
+fn escaped_no_op_inner(buf: &mut dyn Write) {
+    let h = "hello world";
+    for _ in 0..1000 {
+        h.to_html(buf).unwrap();
+        h.to_html(buf).unwrap();
+        h.to_html(buf).unwrap();
+    }
+}
+
+#[bench]
+fn escaped_nums(b: &mut Bencher) {
+    b.iter(|| {
+        let mut buf = Vec::with_capacity(10000);
+        escaped_nums_inner(&mut buf);
+        buf
+    });
+}
+
+#[inline(never)]
+fn escaped_nums_inner(buf: &mut dyn Write) {
+    for i in 0..1000 {
+        i.to_html(buf).unwrap();
+        5.to_html(buf).unwrap();
+        i.to_html(buf).unwrap();
+    }
+}
+
+#[bench]
+fn escaped_short(b: &mut Bencher) {
+    b.iter(|| {
+        let mut buf = Vec::with_capacity(10000);
+        escaped_short_inner(&mut buf);
+        buf
+    });
+}
+
+#[inline(never)]
+fn escaped_short_inner(buf: &mut dyn Write) {
+    for _ in 0..1000 {
+        "hello&world".to_html(buf).unwrap();
+        "hi".to_html(buf).unwrap();
+        "hello=world!".to_html(buf).unwrap();
+    }
+}
+
+#[bench]
+fn escaped_long(b: &mut Bencher) {
+    b.iter(|| {
+        let mut buf = Vec::with_capacity(10000);
+        escaped_long_inner(&mut buf);
+        buf
+    });
+}
+
+#[inline(never)]
+fn escaped_long_inner(buf: &mut dyn Write) {
+    for _ in 0..100 {
+        let h = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit <in> voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+        h.to_html(buf).unwrap();
+        h.to_html(buf).unwrap();
+        h.to_html(buf).unwrap();
+    }
+}

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -218,7 +218,7 @@ fn test_explicit_formatting() {
     assert_eq!(
         r2s(|o| explicit_formatting(o, 5.212432234, "one\ntwo")),
         "<p>Value 1 is 5.2 (or really 5.212432234),\n\
-         while value 2 is \"one\\ntwo\".</p>\n"
+         while value 2 is &quot;one\\ntwo&quot;.</p>\n"
     );
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -734,9 +734,46 @@ pub mod templates {
     #[test]
     fn encoded() {
         let mut buf = Vec::new();
-        "a < b".to_html(&mut buf).unwrap();
-        assert_eq!(b"a &lt; b", &buf[..]);
+        "a < b\0\n".to_html(&mut buf).unwrap();
+        assert_eq!(b"a &lt; b\0\n", &buf[..]);
+
+        let mut buf = Vec::new();
+        "'b".to_html(&mut buf).unwrap();
+        assert_eq!(b"&#39;b", &buf[..]);
+
+        let mut buf = Vec::new();
+        "xxxxx>&".to_html(&mut buf).unwrap();
+        assert_eq!(b"xxxxx&gt;&amp;", &buf[..]);
     }
+
+    #[test]
+    fn encoded_empty() {
+        let mut buf = Vec::new();
+        "".to_html(&mut buf).unwrap();
+        "".to_html(&mut buf).unwrap();
+        "".to_html(&mut buf).unwrap();
+        assert_eq!(b"", &buf[..]);
+    }
+
+    #[test]
+    fn double_encoded() {
+        let mut buf = Vec::new();
+        "&amp;".to_html(&mut buf).unwrap();
+        "&lt;".to_html(&mut buf).unwrap();
+        assert_eq!(b"&amp;amp;&amp;lt;", &buf[..]);
+    }
+
+    #[test]
+    fn encoded_only() {
+        let mut buf = Vec::new();
+        "&&&&&&&&&&&&&&&&".to_html(&mut buf).unwrap();
+        assert_eq!(b"&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;" as &[u8], &buf[..]);
+
+        let mut buf = Vec::new();
+        "''''''''''''''".to_html(&mut buf).unwrap();
+        assert_eq!(b"&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;" as &[u8], &buf[..]);
+    }
+
     #[test]
     fn raw_html() {
         let mut buf = Vec::new();

--- a/src/template_utils.rs
+++ b/src/template_utils.rs
@@ -6,6 +6,7 @@
 /// formats the value using Display and then html-encodes the result.
 pub trait ToHtml {
     /// Write self to `out`, which is in html representation.
+    #[inline]
     fn to_html(&self, out: &mut Write) -> io::Result<()>;
 }
 
@@ -15,23 +16,56 @@ pub trait ToHtml {
 pub struct Html<T> (pub T);
 
 impl<T: Display> ToHtml for Html<T> {
+    #[inline]
     fn to_html(&self, out: &mut Write) -> io::Result<()> {
         write!(out, "{}", self.0)
     }
 }
 
 impl<T: Display> ToHtml for T {
+    #[inline]
     fn to_html(&self, out: &mut Write) -> io::Result<()> {
-        let mut buf = Vec::new();
-        write!(buf, "{}", self)?;
-        out.write_all(&buf.into_iter().fold(Vec::new(), |mut v, c| {
-            match c {
-                b'<' => v.extend_from_slice(b"&lt;"),
-                b'>' => v.extend_from_slice(b"&gt;"),
-                b'&' => v.extend_from_slice(b"&amp;"),
-                c => v.push(c),
-            };
-            v
-        }))
+        write!(ToHtmlEscapingWriter(out), "{}", self)
+    }
+}
+
+struct ToHtmlEscapingWriter<'a>(&'a mut Write);
+
+impl<'a> Write for ToHtmlEscapingWriter<'a> {
+    #[inline]
+    // This takes advantage of the fact that `write` doesn't have to write everything,
+    // and the call will be retried with the rest of the data
+    // (it is a part of `write_all`'s loop or similar.)
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        // quickly skip over data that doesn't need escaping
+        let n = data.into_iter().take_while(|&&c| c != b'"' && c != b'&' && c != b'\'' && c != b'<' && c != b'>').count();
+        if n > 0 {
+            self.0.write(&data[0..n])
+        } else {
+            Self::write_one_byte_escaped(&mut self.0, data)
+        }
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}
+
+impl<'a> ToHtmlEscapingWriter<'a> {
+    #[inline(never)]
+    fn write_one_byte_escaped(out: &mut Write, data: &[u8]) -> io::Result<usize> {
+        let next = data.get(0);
+        out.write_all(match next {
+            Some(b'"') => b"&quot;",
+            Some(b'&') => b"&amp;",
+            Some(b'<') => b"&lt;",
+            Some(b'>') => b"&gt;",
+            None => return Ok(0),
+            // we know this function is called only for chars that need escaping,
+            // so we don't have to handle the "other" case (this one is for `'`)
+            _ => b"&#39;",
+        })?;
+        Ok(1)
     }
 }


### PR DESCRIPTION
Implements `Write` directly, and completely avoids buffering.

```
  name           before ns/iter  after ns/iter  diff ns/iter   diff %  speedup
 escaped_long   470,827         74,397             -396,430  -84.20%   x 6.33
 escaped_no_op  932,461         100,630            -831,831  -89.21%   x 9.27
 escaped_nums   671,093         110,713            -560,380  -83.50%   x 6.06
 escaped_short  872,820         115,387            -757,433  -86.78%   x 7.56
 raw            24,583          24,437                 -146   -0.59%   x 1.01
```