### PR TITLE
Make the build scripts nicer.

### DIFF
--- a/examples/ed2018/src/build.rs
+++ b/examples/ed2018/src/build.rs
@@ -1,14 +1,9 @@
-extern crate ructe;
+use ructe::{Result, Ructe};
 
-use ructe::{compile_templates, StaticFiles};
-use std::env;
-use std::path::PathBuf;
-
-fn main() {
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let in_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    let mut statics = StaticFiles::new(&out_dir).unwrap();
-    statics.add_files(&in_dir.join("static")).unwrap();
-    statics.add_sass_file(&in_dir.join("style.scss")).unwrap();
-    compile_templates(&in_dir.join("templates"), &out_dir).unwrap();
+fn main() -> Result<()> {
+    let mut ructe = Ructe::from_env()?;
+    let mut statics = ructe.statics()?;
+    statics.add_files("static")?;
+    statics.add_sass_file("style.scss")?;
+    ructe.compile_templates("templates")
 }

--- a/examples/gotham/src/build.rs
+++ b/examples/gotham/src/build.rs
@@ -2,15 +2,12 @@
 //! which can then be `include!`d in `main.rs`.
 extern crate ructe;
 
-use ructe::{compile_templates, StaticFiles};
-use std::env;
-use std::path::PathBuf;
+use ructe::{Result, Ructe};
 
-fn main() {
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let base_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    let mut statics = StaticFiles::new(&out_dir).unwrap();
-    statics.add_files(&base_dir.join("statics")).unwrap();
-    statics.add_sass_file(&base_dir.join("style.scss")).unwrap();
-    compile_templates(&base_dir.join("templates"), &out_dir).unwrap();
+fn main() -> Result<()> {
+    let mut ructe = Ructe::from_env()?;
+    let mut statics = ructe.statics()?;
+    statics.add_files("statics")?;
+    statics.add_sass_file("style.scss")?;
+    ructe.compile_templates("templates")
 }

--- a/examples/iron/src/build.rs
+++ b/examples/iron/src/build.rs
@@ -1,16 +1,19 @@
 //! This job builds rust source from static files and templates,
 //! which can then be `include!`d in `main.rs`.
+//!
+//! This build scritps uses deprecated functionality, mainly to have
+//! something still use it until I actually remove it.
 extern crate ructe;
 
-use ructe::{compile_templates, StaticFiles};
+use ructe::{compile_templates, Result, StaticFiles};
 use std::env;
 use std::path::PathBuf;
 
-fn main() {
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let base_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    let mut statics = StaticFiles::new(&out_dir).unwrap();
-    statics.add_files(&base_dir.join("statics")).unwrap();
-    statics.add_sass_file(&base_dir.join("style.scss")).unwrap();
-    compile_templates(&base_dir.join("templates"), &out_dir).unwrap();
+fn main() -> Result<()> {
+    let out_dir = PathBuf::from(env::var("OUT_DIR")?);
+    let base_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
+    let mut statics = StaticFiles::new(&out_dir)?;
+    statics.add_files(&base_dir.join("statics"))?;
+    statics.add_sass_file(&base_dir.join("style.scss"))?;
+    compile_templates(&base_dir.join("templates"), &out_dir)
 }

--- a/examples/nickel/src/build.rs
+++ b/examples/nickel/src/build.rs
@@ -2,15 +2,12 @@
 //! which can then be `include!`d in `main.rs`.
 extern crate ructe;
 
-use ructe::{compile_templates, StaticFiles};
-use std::env;
-use std::path::PathBuf;
+use ructe::{Result, Ructe};
 
-fn main() {
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let base_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    let mut statics = StaticFiles::new(&out_dir).unwrap();
-    statics.add_files(&base_dir.join("statics")).unwrap();
-    statics.add_sass_file(&base_dir.join("style.scss")).unwrap();
-    compile_templates(&base_dir.join("templates"), &out_dir).unwrap();
+fn main() -> Result<()> {
+    let mut ructe = Ructe::from_env()?;
+    let mut statics = ructe.statics()?;
+    statics.add_files("statics")?;
+    statics.add_sass_file("style.scss")?;
+    ructe.compile_templates("templates")
 }

--- a/examples/simple/src/build.rs
+++ b/examples/simple/src/build.rs
@@ -1,12 +1,7 @@
 extern crate ructe;
 
-use ructe::compile_templates;
-use std::env;
-use std::path::PathBuf;
+use ructe::{Result, Ructe};
 
-fn main() {
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let in_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
-        .join("templates");
-    compile_templates(&in_dir, &out_dir).expect("foo");
+fn main() -> Result<()> {
+    Ructe::from_env()?.compile_templates("templates")
 }

--- a/examples/static-sass/src/build.rs
+++ b/examples/static-sass/src/build.rs
@@ -1,16 +1,12 @@
 extern crate ructe;
 
-use ructe::{compile_templates, StaticFiles};
-use std::env;
-use std::path::PathBuf;
+use ructe::{Ructe, RucteError};
 
-fn main() {
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let base_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    let mut statics = StaticFiles::new(&out_dir).unwrap();
-    statics.add_files(&base_dir.join("static")).unwrap();
-    statics.add_sass_file("scss/style.scss".as_ref()).unwrap();
+fn main() -> Result<(), RucteError> {
+    let mut ructe = Ructe::from_env()?;
+    let mut statics = ructe.statics()?;
+    statics.add_files("static")?;
+    statics.add_sass_file("scss/style.scss")?;
 
-    let template_dir = base_dir.join("templates");
-    compile_templates(&template_dir, &out_dir).expect("templates");
+    ructe.compile_templates("templates")
 }

--- a/examples/statics/src/build.rs
+++ b/examples/statics/src/build.rs
@@ -1,12 +1,9 @@
 extern crate ructe;
 
-use ructe::{compile_static_files, compile_templates};
-use std::env;
-use std::path::PathBuf;
+use ructe::{Ructe, RucteError};
 
-fn main() {
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let in_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    compile_static_files(&in_dir.join("static"), &out_dir).unwrap();
-    compile_templates(&in_dir.join("templates"), &out_dir).unwrap();
+fn main() -> Result<(), RucteError> {
+    let mut ructe = Ructe::from_env()?;
+    ructe.statics()?.add_files("static")?;
+    ructe.compile_templates("templates")
 }

--- a/examples/warp/src/build.rs
+++ b/examples/warp/src/build.rs
@@ -1,16 +1,11 @@
 //! This job builds rust source from static files and templates,
 //! which can then be `include!`d in `main.rs`.
-extern crate ructe;
+use ructe::{Ructe, RucteError};
 
-use ructe::{compile_templates, StaticFiles};
-use std::env;
-use std::path::PathBuf;
-
-fn main() {
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let base_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    let mut statics = StaticFiles::new(&out_dir).unwrap();
-    statics.add_files(&base_dir.join("statics")).unwrap();
-    statics.add_sass_file(&base_dir.join("style.scss")).unwrap();
-    compile_templates(&base_dir.join("templates"), &out_dir).unwrap();
+fn main() -> Result<(), RucteError> {
+    let mut ructe = Ructe::from_env()?;
+    let mut statics = ructe.statics()?;
+    statics.add_files("statics")?;
+    statics.add_sass_file("style.scss")?;
+    ructe.compile_templates("templates")
 }

--- a/examples/warp/src/main.rs
+++ b/examples/warp/src/main.rs
@@ -1,8 +1,4 @@
 //! An example web service using ructe with the warp framework.
-extern crate env_logger;
-extern crate mime;
-extern crate warp;
-
 mod render_ructe;
 
 use render_ructe::RenderRucte;

--- a/src/How_to_use_ructe.rs
+++ b/src/How_to_use_ructe.rs
@@ -20,17 +20,10 @@
 //! directory and put the output where cargo tells it to:
 //!
 //! ```rust,no_run
-//! extern crate ructe;
+//! use ructe::{Result, Ructe};
 //!
-//! use ructe::compile_templates;
-//! use std::env;
-//! use std::path::PathBuf;
-//!
-//! fn main() {
-//!     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-//!     let in_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
-//!         .join("templates");
-//!     compile_templates(&in_dir, &out_dir).expect("compile templates");
+//! fn main() -> Result<()> {
+//!     Ructe::from_env()?.compile_templates("templates")
 //! }
 //! ```
 //!

--- a/src/Using_static_files.rs
+++ b/src/Using_static_files.rs
@@ -32,13 +32,13 @@ pub mod a_Overview {
     //! ructe to find and transpile your static files:
     //!
     //! ```no_run
-    //! # use ructe::{compile_static_files, compile_templates};
-    //! # use std::env;
-    //! # use std::path::PathBuf;
-    //! let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    //! let in_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    //! compile_static_files(&in_dir.join("static"), &out_dir).unwrap();
-    //! compile_templates(&in_dir.join("templates"), &out_dir).unwrap();
+    //! # extern crate ructe;
+    //! # use ructe::{Ructe, RucteError};
+    //! # fn main() -> Result<(), RucteError> {
+    //! let mut ructe = Ructe::from_env()?;
+    //! ructe.statics()?.add_files("static")?;
+    //! ructe.compile_templates("templates")
+    //! # }
     //! ```
     //!
     //! Then you need to link to the encoded file.


### PR DESCRIPTION
Provide a struct Ructe with methods to handle the red tape from build scripts.  Make the remaining parts of the build scripts shorter and more to the point.