### PR TITLE
Use `impl Write` or generic argument instead of dynamic traits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rust:
   - 1.29.0
   - 1.28.0
   - 1.27.2
-  - 1.26.2
   - beta
   - nightly
 matrix:

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -17,10 +17,10 @@ fn raw(b: &mut Bencher) {
     });
 }
 
-/// real template is a function that takes `dyn Write`, so non-inlineable
+/// real template is a function that takes a generic `Write` parameter, so non-inlineable
 /// function should simulate that instead of allowing optimizer to specialize for `Vec`
 #[inline(never)]
-fn raw_inner(buf: &mut dyn Write) {
+fn raw_inner(buf: &mut impl Write) {
     // inner loop to stress escaping more than buffer allocation
     for _ in 0..1000 {
         let h = Html("Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod");
@@ -38,7 +38,7 @@ fn escaped_no_op(b: &mut Bencher) {
 }
 
 #[inline(never)]
-fn escaped_no_op_inner(buf: &mut dyn Write) {
+fn escaped_no_op_inner(buf: &mut impl Write) {
     let h = "hello world";
     for _ in 0..1000 {
         h.to_html(buf).unwrap();
@@ -57,7 +57,7 @@ fn escaped_nums(b: &mut Bencher) {
 }
 
 #[inline(never)]
-fn escaped_nums_inner(buf: &mut dyn Write) {
+fn escaped_nums_inner(buf: &mut impl Write) {
     for i in 0..1000 {
         i.to_html(buf).unwrap();
         5.to_html(buf).unwrap();
@@ -75,7 +75,7 @@ fn escaped_short(b: &mut Bencher) {
 }
 
 #[inline(never)]
-fn escaped_short_inner(buf: &mut dyn Write) {
+fn escaped_short_inner(buf: &mut impl Write) {
     for _ in 0..1000 {
         "hello&world".to_html(buf).unwrap();
         "hi".to_html(buf).unwrap();
@@ -93,7 +93,7 @@ fn escaped_long(b: &mut Bencher) {
 }
 
 #[inline(never)]
-fn escaped_long_inner(buf: &mut dyn Write) {
+fn escaped_long_inner(buf: &mut impl Write) {
     for _ in 0..100 {
         let h = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,11 @@ pub fn compile_templates(indir: &Path, outdir: &Path) -> Result<()> {
     Ok(())
 }
 
-fn handle_entries(f: &mut impl Write, indir: &Path, outdir: &Path) -> Result<()> {
+fn handle_entries(
+    f: &mut impl Write,
+    indir: &Path,
+    outdir: &Path,
+) -> Result<()> {
     println!("cargo:rerun-if-changed={}", indir.display());
     let suffix = ".rs.html";
     for entry in read_dir(indir)? {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,7 @@ pub fn compile_templates(indir: &Path, outdir: &Path) -> Result<()> {
     Ok(())
 }
 
-fn handle_entries(f: &mut Write, indir: &Path, outdir: &Path) -> Result<()> {
+fn handle_entries(f: &mut impl Write, indir: &Path, outdir: &Path) -> Result<()> {
     println!("cargo:rerun-if-changed={}", indir.display());
     let suffix = ".rs.html";
     for entry in read_dir(indir)? {
@@ -397,7 +397,7 @@ fn handle_template(
 }
 
 fn show_errors<E>(
-    out: &mut Write,
+    out: &mut impl Write,
     buf: &[u8],
     result: nom::IResult<Input, E>,
     prefix: &str,
@@ -441,7 +441,7 @@ fn get_message(err: &ErrorKind) -> String {
 }
 
 fn show_error(
-    out: &mut Write,
+    out: &mut impl Write,
     buf: &[u8],
     pos: usize,
     msg: &str,

--- a/src/staticfiles.rs
+++ b/src/staticfiles.rs
@@ -495,7 +495,7 @@ impl StaticFile {
         path: &Path,
         rust_name: &str,
         url_name: &str,
-        content: &Display,
+        content: &impl Display,
         suffix: &str,
     ) -> io::Result<()> {
         let rust_name = rust_name

--- a/src/template.rs
+++ b/src/template.rs
@@ -28,7 +28,7 @@ impl Template {
         writeln!(
             out,
             "\n\
-             pub fn {name}(out: &mut Write{args}) -> io::Result<()> {{\n\
+             pub fn {name}<W: Write>(out: &mut W{args}) -> io::Result<()> {{\n\
              {body}\
              Ok(())\n\
              }}",
@@ -38,7 +38,7 @@ impl Template {
                     ", {}",
                     arg.replace(
                         " Content",
-                        " impl FnOnce(&mut Write) -> io::Result<()>"
+                        " impl FnOnce(&mut W) -> io::Result<()>"
                     )
                 ))),
             body = self.body.iter().map(|b| b.code()).format(""),

--- a/src/template.rs
+++ b/src/template.rs
@@ -13,7 +13,11 @@ pub struct Template {
 }
 
 impl Template {
-    pub fn write_rust(&self, out: &mut impl Write, name: &str) -> io::Result<()> {
+    pub fn write_rust(
+        &self,
+        out: &mut impl Write,
+        name: &str,
+    ) -> io::Result<()> {
         out.write_all(
             b"use std::io::{self, Write};\n\
              #[allow(renamed_and_removed_lints)]\n\

--- a/src/template.rs
+++ b/src/template.rs
@@ -13,7 +13,7 @@ pub struct Template {
 }
 
 impl Template {
-    pub fn write_rust(&self, out: &mut Write, name: &str) -> io::Result<()> {
+    pub fn write_rust(&self, out: &mut impl Write, name: &str) -> io::Result<()> {
         out.write_all(
             b"use std::io::{self, Write};\n\
              #[allow(renamed_and_removed_lints)]\n\

--- a/src/template.rs
+++ b/src/template.rs
@@ -28,7 +28,7 @@ impl Template {
         writeln!(
             out,
             "\n\
-             pub fn {name}<W: Write>(out: &mut W{args}) -> io::Result<()> {{\n\
+             pub fn {name}<W: Write>(mut out: W{args}) -> io::Result<()> {{\n\
              {body}\
              Ok(())\n\
              }}",

--- a/src/template_utils.rs
+++ b/src/template_utils.rs
@@ -6,7 +6,7 @@
 /// formats the value using Display and then html-encodes the result.
 pub trait ToHtml {
     /// Write self to `out`, which is in html representation.
-    fn to_html(&self, out: &mut impl Write) -> io::Result<()>;
+    fn to_html(&self, out: &mut dyn Write) -> io::Result<()>;
 }
 
 /// Wrapper object for data that should be outputted as raw html
@@ -16,21 +16,21 @@ pub struct Html<T>(pub T);
 
 impl<T: Display> ToHtml for Html<T> {
     #[inline]
-    fn to_html(&self, out: &mut impl Write) -> io::Result<()> {
+    fn to_html(&self, out: &mut dyn Write) -> io::Result<()> {
         write!(out, "{}", self.0)
     }
 }
 
 impl<T: Display> ToHtml for T {
     #[inline]
-    fn to_html(&self, out: &mut impl Write) -> io::Result<()> {
+    fn to_html(&self, out: &mut dyn Write) -> io::Result<()> {
         write!(ToHtmlEscapingWriter(out), "{}", self)
     }
 }
 
-struct ToHtmlEscapingWriter<'a, W: Write>(&'a mut W);
+struct ToHtmlEscapingWriter<'a>(&'a mut dyn Write);
 
-impl<'a, W: Write> Write for ToHtmlEscapingWriter<'a, W> {
+impl<'a> Write for ToHtmlEscapingWriter<'a> {
     #[inline]
     // This takes advantage of the fact that `write` doesn't have to write everything,
     // and the call will be retried with the rest of the data
@@ -56,7 +56,7 @@ impl<'a, W: Write> Write for ToHtmlEscapingWriter<'a, W> {
     }
 }
 
-impl<'a, W: Write> ToHtmlEscapingWriter<'a, W> {
+impl<'a> ToHtmlEscapingWriter<'a> {
     #[inline(never)]
     fn write_one_byte_escaped(
         out: &mut impl Write,

--- a/src/template_utils_warp.rs
+++ b/src/template_utils_warp.rs
@@ -48,13 +48,13 @@ pub trait RenderRucte {
     /// This is the main function of the trait.  Please see the trait documentation.
     fn html<F>(&mut self, f: F) -> Result<Response<Vec<u8>>, Rejection>
     where
-        F: FnOnce(&mut Write) -> io::Result<()>;
+        F: FnOnce(&mut Vec<u8>) -> io::Result<()>;
 }
 
 impl RenderRucte for Builder {
     fn html<F>(&mut self, f: F) -> Result<Response<Vec<u8>>, Rejection>
     where
-        F: FnOnce(&mut Write) -> io::Result<()>,
+        F: FnOnce(&mut Vec<u8>) -> io::Result<()>,
     {
         let mut buf = Vec::new();
         f(&mut buf).map_err(custom)?;

--- a/src/templateexpression.rs
+++ b/src/templateexpression.rs
@@ -46,7 +46,7 @@ impl Display for TemplateArgument {
             }
             TemplateArgument::Body(ref v) => writeln!(
                 out,
-                "|out| {{\n{}\nOk(())\n}}",
+                "|mut out| {{\n{}\nOk(())\n}}",
                 v.iter().map(|b| b.code()).format(""),
             ),
         }
@@ -69,7 +69,7 @@ impl TemplateExpression {
                 format!("out.write_all({:?}.as_bytes())?;\n", text)
             }
             TemplateExpression::Expression { ref expr } => {
-                format!("{}.to_html(out)?;\n", expr)
+                format!("{}.to_html(&mut out)?;\n", expr)
             }
             TemplateExpression::ForLoop {
                 ref name,
@@ -96,7 +96,7 @@ impl TemplateExpression {
             ),
             TemplateExpression::CallTemplate { ref name, ref args } => {
                 format!(
-                    "{}(out{})?;\n",
+                    "{}(&mut out{})?;\n",
                     name,
                     args.iter().format_with("", |arg, f| f(&format_args!(
                         ", {}",


### PR DESCRIPTION
This replaces the use of `&mut Write` with either `&mut impl Write` or a generic `W: Write` argument. in both the generated code and in internal code. In template functions, I had to use a generic parameter because `impl Trait` cannot be nested, but nested templates are supported. Elsewhere, such as in the ToHtml trait, `impl Trait` is used. 

This removes all warnings I get on nightly and provides a performance increase. The benchmarks with `master` branch on my computer produce:
```
running 5 tests
test escaped_long  ... bench:     126,897 ns/iter (+/- 7,196)
test escaped_no_op ... bench:     107,261 ns/iter (+/- 2,043)
test escaped_nums  ... bench:     113,412 ns/iter (+/- 1,941)
test escaped_short ... bench:     119,796 ns/iter (+/- 2,596)
test raw           ... bench:      30,960 ns/iter (+/- 504)
```

And with this PR:
```
test escaped_long  ... bench:     126,358 ns/iter (+/- 6,172)
test escaped_no_op ... bench:     108,858 ns/iter (+/- 24,152)
test escaped_nums  ... bench:     113,939 ns/iter (+/- 2,237)
test escaped_short ... bench:     120,879 ns/iter (+/- 4,276)
test raw           ... bench:      25,951 ns/iter (+/- 915)
```

If I replace the dynamic arguments in ToHtml as well, which breaks existing example code since ToHtml cannot be made into atrait object anymore, I get
```
running 5 tests
test escaped_long  ... bench:     122,710 ns/iter (+/- 1,656)
test escaped_no_op ... bench:     101,955 ns/iter (+/- 5,278)
test escaped_nums  ... bench:     107,531 ns/iter (+/- 2,971)
test escaped_short ... bench:     111,749 ns/iter (+/- 2,788)
test raw           ... bench:      25,785 ns/iter (+/- 299)
```
Fixes issue https://github.com/kaj/ructe/issues/47