### PR TITLE
Avoid dyn in to_html

### DIFF
--- a/src/template_utils.rs
+++ b/src/template_utils.rs
@@ -6,7 +6,7 @@
 /// formats the value using Display and then html-encodes the result.
 pub trait ToHtml {
     /// Write self to `out`, which is in html representation.
-    fn to_html(&self, out: &mut dyn Write) -> io::Result<()>;
+    fn to_html<W>(&self, out: &mut W) -> io::Result<()> where W: ?Sized, for<'a> &'a mut W: Write;
 }
 
 /// Wrapper object for data that should be outputted as raw html
@@ -16,21 +16,21 @@ pub struct Html<T>(pub T);
 
 impl<T: Display> ToHtml for Html<T> {
     #[inline]
-    fn to_html(&self, out: &mut dyn Write) -> io::Result<()> {
+    fn to_html<W>(&self, mut out: &mut W) -> io::Result<()>  where W: ?Sized, for<'a> &'a mut W: Write {
         write!(out, "{}", self.0)
     }
 }
 
 impl<T: Display> ToHtml for T {
     #[inline]
-    fn to_html(&self, out: &mut dyn Write) -> io::Result<()> {
+    fn to_html<W>(&self, out: &mut W) -> io::Result<()>  where W: ?Sized, for<'a> &'a mut W: Write {
         write!(ToHtmlEscapingWriter(out), "{}", self)
     }
 }
 
-struct ToHtmlEscapingWriter<'a>(&'a mut dyn Write);
+struct ToHtmlEscapingWriter<'w, W: ?Sized>(&'w mut W);
 
-impl<'a> Write for ToHtmlEscapingWriter<'a> {
+impl<'w, W> Write for ToHtmlEscapingWriter<'w, W> where W: ?Sized, for<'a> &'a mut W: Write {
     #[inline]
     // This takes advantage of the fact that `write` doesn't have to write everything,
     // and the call will be retried with the rest of the data
@@ -56,10 +56,10 @@ impl<'a> Write for ToHtmlEscapingWriter<'a> {
     }
 }
 
-impl<'a> ToHtmlEscapingWriter<'a> {
+impl<'w, W> ToHtmlEscapingWriter<'w, W> where W: ?Sized, for<'a> &'a mut W: Write {
     #[inline(never)]
     fn write_one_byte_escaped(
-        out: &mut impl Write,
+        mut out: &mut W,
         data: &[u8],
     ) -> io::Result<usize> {
         let next = data.get(0);


### PR DESCRIPTION
Makes benchmarks slightly better:

```
 name                before ns/iter  after ns/iter  diff ns/iter   diff %  speedup
 escaped_long        75,357          70,066               -5,291   -7.02%   x 1.08
 escaped_no_op       92,623          74,609              -18,014  -19.45%   x 1.24
 escaped_nums        104,926         81,901              -23,025  -21.94%   x 1.28
 escaped_short_dyn   123,600         105,811             -17,789  -14.39%   x 1.17
 escaped_short_impl  113,133         90,689              -22,444  -19.84%   x 1.25
 raw                 27,895          26,434               -1,461   -5.24%   x 1.06
```

(the comparison is with improved benchmark code in both cases)