### PR TITLE
Require buf reference to implement Write, not buf itself

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -41,7 +41,7 @@ impl Template {
         writeln!(
             out,
             "\n\
-             pub fn {name}<W: Write>(mut out: W{args}) -> io::Result<()> {{\n\
+             pub fn {name}<W>(mut out: &mut W{args}) -> io::Result<()> where W: ?Sized, for<'a> &'a mut W: Write {{\n\
              {body}\
              Ok(())\n\
              }}",


### PR DESCRIPTION
I've noticed that previous `Write` requirement wasn't quite right:

```rust
(out: &mut impl Write)
<W: Write>(out: &mut W)
```

requires mutable reference to something that implements `Write`. However, `out` itself is used in contexts where `Write` is required, therefore `Write` needs to be implemented only on the reference, not necessarily on the referred object.

This worked fine before because most objects implement `Write` themselves, and there's blanket implementation that makes `&mut Write` implement `Write`, but there are exceptions, for example `[u8]` doesn't implement write, but `&mut [u8]` does.
