### PR TITLE
An expression starting with paren ends on close.

### DIFF
--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -286,3 +286,15 @@ fn test_page_two() {
          \n</html>\n\n",
     )
 }
+
+#[test]
+fn test_some_expressions() {
+    assert_eq!(
+        r2s(|o| some_expressions(o, "name")),
+        "<p>name</p>\
+         \n<p>name.name</p>\
+         \n<p>4</p>\
+         \n<p>name.len()</p>\
+         \n<p>1</p>\n"
+    )
+}

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -295,6 +295,7 @@ fn test_some_expressions() {
          \n<p>name.name</p>\
          \n<p>4</p>\
          \n<p>name.len()</p>\
+         \n<p>-1</p>\
          \n<p>1</p>\n"
     )
 }

--- a/examples/simple/templates/some_expressions.rs.html
+++ b/examples/simple/templates/some_expressions.rs.html
@@ -1,0 +1,7 @@
+@(arg: &str)
+
+<p>@arg</p>
+<p>@arg.@arg</p>
+<p>@arg.len()</p>
+<p>@(arg).len()</p>
+<p>@((2_i8 - 3).abs())</p>@* Note extra parens needed here *@

--- a/examples/simple/templates/some_expressions.rs.html
+++ b/examples/simple/templates/some_expressions.rs.html
@@ -4,4 +4,5 @@
 <p>@arg.@arg</p>
 <p>@arg.len()</p>
 <p>@(arg).len()</p>
+<p>@(2_i8 - 3)</p>
 <p>@((2_i8 - 3).abs())</p>@* Note extra parens needed here *@

--- a/src/Template_syntax.rs
+++ b/src/Template_syntax.rs
@@ -99,6 +99,10 @@ pub mod a_Value_expressions {
     //! ```text
     //! <p>The sum @a+3 is @(a+3).</p>
     //! ```
+    //! If `a` is 2, this exapands to:
+    //! ```text
+    //! <p>The sum 2+3 is 5.</p>
+    //! ```
     //!
     //! Anything is allowed in parenthesis, as long as parenthesis,
     //! brackets and string quotes are balanced.
@@ -109,6 +113,32 @@ pub mod a_Value_expressions {
     //! ```text
     //! <p>Index: @myvec[t.map(|s| s.length()).unwrap_or(0)].</p>
     //! <p>Argument: @call(a + 3, |t| t.something()).</p>
+    //! ```
+    //!
+    //! An expression ends when parenthesis and brackets are matched
+    //! and it is followed by something not allowed in an expression.
+    //! This includes whitespace and e.g. the `<` and `@` characters.
+    //! If an expression starts with an open parenthesis, the
+    //! expression ends when that parentheis is closed.
+    //! That is usefull if an expression is to be emmediatley followed
+    //! by something that would be allowed in an expression.
+    //!
+    //! ```text
+    //! <p>@arg</p>
+    //! <p>@arg.</p>
+    //! <p>@arg.@arg</p>
+    //! <p>@arg.len()</p>
+    //! <p>@(arg).len()</p>
+    //! <p>@((2_i8 - 3).abs())</p>@* Note extra parens needed here *@
+    //! ```
+    //! With `arg = "name"`, the above renders as:
+    //! ```text
+    //! <p>name</p>
+    //! <p>name.</p>
+    //! <p>name.name</p>
+    //! <p>4</p>
+    //! <p>name.len()</p>
+    //! <p>1</p>
     //! ```
 }
 

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -63,19 +63,7 @@ pub fn rust_name(input: &[u8]) -> PResult<&str> {
 
 fn expr_in_parens(input: &[u8]) -> PResult<&str> {
     map_res(
-        recognize(delimited(
-            tag("("),
-            many0(alt((
-                value((), is_not("[]()\"/")),
-                value((), expr_in_braces),
-                value((), expr_in_brackets),
-                value((), expr_in_parens),
-                value((), quoted_string),
-                value((), rust_comment),
-                value((), terminated(tag("/"), none_of("*"))),
-            ))),
-            tag(")"),
-        )),
+        recognize(delimited(tag("("), expr_inside_parens, tag(")"))),
         input_to_str,
     )(input)
 }
@@ -113,6 +101,21 @@ pub fn expr_in_braces(input: &[u8]) -> PResult<&str> {
             ))),
             tag("}"),
         )),
+        input_to_str,
+    )(input)
+}
+
+pub fn expr_inside_parens(input: &[u8]) -> PResult<&str> {
+    map_res(
+        recognize(many0(alt((
+            value((), is_not("{}[]()\"/")),
+            value((), expr_in_braces),
+            value((), expr_in_brackets),
+            value((), expr_in_parens),
+            value((), quoted_string),
+            value((), rust_comment),
+            value((), terminated(tag("/"), none_of("*"))),
+        )))),
         input_to_str,
     )(input)
 }

--- a/src/templateexpression.rs
+++ b/src/templateexpression.rs
@@ -1,5 +1,6 @@
 use expression::{
-    comma_expressions, expr_in_braces, expression, input_to_str, rust_name,
+    comma_expressions, expr_in_braces, expr_inside_parens, expression,
+    input_to_str, rust_name,
 };
 use itertools::Itertools;
 use nom::branch::alt;
@@ -194,11 +195,13 @@ pub fn template_expression(input: &[u8]) -> PResult<TemplateExpression> {
                 body,
             },
         )(i),
-        (i, Some(b"(")) => map(terminated(expression, tag(")")), |expr| {
-            TemplateExpression::Expression {
-                expr: expr.to_string(),
-            }
-        })(i),
+        (i, Some(b"(")) => {
+            map(terminated(expr_inside_parens, tag(")")), |expr| {
+                TemplateExpression::Expression {
+                    expr: format!("({})", expr),
+                }
+            })(i)
+        }
         (i, Some(b"")) => {
             map(expression, |expr| TemplateExpression::Expression {
                 expr: expr.to_string(),

--- a/src/templateexpression.rs
+++ b/src/templateexpression.rs
@@ -125,6 +125,7 @@ pub fn template_expression(input: &[u8]) -> PResult<TemplateExpression> {
             tag("@"),
             tag("{"),
             tag("}"),
+            tag("("),
             terminated(alt((tag("if"), tag("for"))), tag(" ")),
             value(&b""[..], tag("")),
         )),
@@ -193,6 +194,11 @@ pub fn template_expression(input: &[u8]) -> PResult<TemplateExpression> {
                 body,
             },
         )(i),
+        (i, Some(b"(")) => map(terminated(expression, tag(")")), |expr| {
+            TemplateExpression::Expression {
+                expr: expr.to_string(),
+            }
+        })(i),
         (i, Some(b"")) => {
             map(expression, |expr| TemplateExpression::Expression {
                 expr: expr.to_string(),


### PR DESCRIPTION
BREAKING CHANGE.  If an expression starts with an open parenthesis, the expression ends on the closing parenthesis (and that outer parenthesis is not part of the expression.

This fixes cases where an expression is immediately followed by something that could be part of the expression.

Before this change, calling a function on the result of some subexpression could be written as `@(a - b).abs()`.  After this change, that should be changed to `@((a - b).abs())` unless the intent is to have the result of (a - b) followed by the template string `.abs()`.

Fixes #64.