### PR TITLE
Add support for subresource integrity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT/Apache-2.0"
 
 [features]
 sass = ["rsass"]
+sri = ["ssri"]
 mime02 = []
 mime03 = ["mime"]
 warp02 = ["mime03"]
@@ -24,6 +25,7 @@ md5 = "0.7"
 nom = "5.0.0"
 
 rsass = { version = "0.13.0", optional = true }
+ssri = { version = "5.0.0", optional = true }
 mime = { version = "0.3", optional = true }
 
 [badges]

--- a/examples/actix/Cargo.toml
+++ b/examples/actix/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 build = "src/build.rs"
 
 [build-dependencies]
-ructe = { path = "../..", features = ["sass", "mime03"] }
+ructe = { path = "../..", features = ["sass", "sri", "mime03"] }
 
 [dependencies]
 actix-web = "2.0.0"

--- a/examples/actix/templates/error.rs.html
+++ b/examples/actix/templates/error.rs.html
@@ -9,7 +9,7 @@
   <head>
     <title>Error @code.as_u16(): @code.canonical_reason().unwrap_or("error")</title>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <link rel="stylesheet" type="text/css" href="/static/@style_css.name"/>
+    <link rel="stylesheet" type="text/css" href="/static/@style_css.name" integrity="@style_css.integrity_sha384" />
   </head>
   <body>
     <main>

--- a/examples/actix/templates/page.rs.html
+++ b/examples/actix/templates/page.rs.html
@@ -8,7 +8,7 @@
   <head>
     <title>Example</title>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <link rel="stylesheet" type="text/css" href="/static/@style_css.name"/>
+    <link rel="stylesheet" type="text/css" href="/static/@style_css.name" integrity="@style_css.integrity_sha384" />
   </head>
   <body>
     <main>

--- a/examples/ed2018/Cargo.toml
+++ b/examples/ed2018/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 build = "src/build.rs"
 
 [build-dependencies]
-ructe = { path = "../..", features = ["mime03", "sass"] }
+ructe = { path = "../..", features = ["mime03", "sri", "sass"] }
 
 [dependencies]
 mime = "~0.3"

--- a/examples/ed2018/templates/page.rs.html
+++ b/examples/ed2018/templates/page.rs.html
@@ -4,7 +4,7 @@
 <html>
   <head>
     <title>Example with stylesheet</title>
-    <link rel="stylesheet" href="/static/@style_css.name" type="text/css"/>
+    <link rel="stylesheet" href="/static/@style_css.name" type="text/css" integrity="@style_css.integrity_sha384" />
   </head>
   <body>
     Hello world!

--- a/examples/gotham/Cargo.toml
+++ b/examples/gotham/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Rasmus Kaj <kaj@kth.se>"]
 build = "src/build.rs"
 
 [build-dependencies]
-ructe = { path = "../..", features = ["sass", "mime03"] }
+ructe = { path = "../..", features = ["sass", "sri", "mime03"] }
 
 [dependencies]
 gotham = "0.4.0"

--- a/examples/gotham/templates/page.rs.html
+++ b/examples/gotham/templates/page.rs.html
@@ -8,7 +8,7 @@
   <head>
     <title>Example</title>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <link rel="stylesheet" type="text/css" href="/static/@style_css.name"/>
+    <link rel="stylesheet" type="text/css" href="/static/@style_css.name" integrity="@style_css.integrity_sha384" />
   </head>
   <body>
     <main>

--- a/examples/iron/Cargo.toml
+++ b/examples/iron/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Rasmus Kaj <kaj@kth.se>"]
 build = "src/build.rs"
 
 [build-dependencies]
-ructe = { path = "../..", features = ["sass", "mime02"] }
+ructe = { path = "../..", features = ["sass", "sri", "mime02"] }
 
 [dependencies]
 iron = "0.6"

--- a/examples/iron/templates/page.rs.html
+++ b/examples/iron/templates/page.rs.html
@@ -8,7 +8,7 @@
   <head>
     <title>Example</title>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <link rel="stylesheet" type="text/css" href="/static/@style_css.name"/>
+    <link rel="stylesheet" type="text/css" href="/static/@style_css.name" integrity="@style_css.integrity_sha384" />
   </head>
   <body>
     <main>

--- a/examples/nickel/Cargo.toml
+++ b/examples/nickel/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Rasmus Kaj <kaj@kth.se>"]
 build = "src/build.rs"
 
 [build-dependencies]
-ructe = { path = "../..", features = ["sass", "mime02"] }
+ructe = { path = "../..", features = ["sass", "sri", "mime02"] }
 
 [dependencies]
 nickel = "0.11.0"

--- a/examples/nickel/templates/page.rs.html
+++ b/examples/nickel/templates/page.rs.html
@@ -8,7 +8,7 @@
   <head>
     <title>Example</title>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <link rel="stylesheet" type="text/css" href="/static/@style_css.name"/>
+    <link rel="stylesheet" type="text/css" href="/static/@style_css.name" integrity="@style_css.integrity_sha384" />
   </head>
   <body>
     <main>

--- a/examples/static-sass/Cargo.toml
+++ b/examples/static-sass/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Rasmus Kaj <kaj@kth.se>"]
 build = "src/build.rs"
 
 [build-dependencies]
-ructe = { path = "../..", features = ["sass"] }
+ructe = { path = "../..", features = ["sass", "sri"] }

--- a/examples/static-sass/templates/page.rs.html
+++ b/examples/static-sass/templates/page.rs.html
@@ -4,7 +4,7 @@
 <html>
   <head>
     <title>Example with stylesheet</title>
-    <link rel="stylesheet" href="/static/@style_css.name" type="text/css"/>
+    <link rel="stylesheet" href="/static/@style_css.name" type="text/css" integrity="@style_css.integrity_sha384" />
   </head>
   <body>
     Hello world!

--- a/examples/statics/Cargo.toml
+++ b/examples/statics/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Rasmus Kaj <kaj@kth.se>"]
 build = "src/build.rs"
 
 [build-dependencies]
-ructe = { path = "../..", features = ["mime03"] }
+ructe = { path = "../..", features = ["sri", "mime03"] }
 
 [dependencies]
 mime = "0.3.0"

--- a/examples/statics/templates/page.rs.html
+++ b/examples/statics/templates/page.rs.html
@@ -4,7 +4,7 @@
 <html>
   <head>
     <title>Example with stylesheet</title>
-    <link rel="stylesheet" href="/static/@style_css.name" type="text/css"/>
+    <link rel="stylesheet" href="/static/@style_css.name" type="text/css" integrity="@style_css.integrity_sha384" />
   </head>
   <body>
     Hello world!

--- a/examples/warp02/Cargo.toml
+++ b/examples/warp02/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 build = "src/build.rs"
 
 [build-dependencies]
-ructe = { path = "../..", features = ["warp02", "sass"] }
+ructe = { path = "../..", features = ["warp02", "sass", "sri"] }
 
 [dependencies]
 warp = "0.2.0"

--- a/examples/warp02/templates/error.rs.html
+++ b/examples/warp02/templates/error.rs.html
@@ -9,7 +9,7 @@
   <head>
     <title>Error @code.as_u16(): @code.canonical_reason().unwrap_or("error")</title>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <link rel="stylesheet" type="text/css" href="/static/@style_css.name"/>
+    <link rel="stylesheet" type="text/css" href="/static/@style_css.name" integrity="@style_css.integrity_sha384" />
   </head>
   <body>
     <main>

--- a/examples/warp02/templates/page.rs.html
+++ b/examples/warp02/templates/page.rs.html
@@ -8,7 +8,7 @@
   <head>
     <title>Example</title>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <link rel="stylesheet" type="text/css" href="/static/@style_css.name"/>
+    <link rel="stylesheet" type="text/css" href="/static/@style_css.name" integrity="@style_css.integrity_sha384" />
   </head>
   <body>
     <main>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,9 @@
 //! version 0.2.x of the [mime] crate.
 //! * `warp02` -- Provide an extension to [`Response::Builder`] to
 //! simplify template rendering in the [warp] framework, versions 0.2.x.
+//! * `sri` -- Generate [subresource
+//! integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)
+//! strings using the [ssri] crate
 //!
 //! [`response::Builder`]: ../http/response/struct.Builder.html
 //! [mime]: https://crates.rs/crates/mime
@@ -103,7 +106,7 @@
 //! build = "src/build.rs"
 //!
 //! [build-dependencies]
-//! ructe = { version = "0.6.0", features = ["sass", "mime03"] }
+//! ructe = { version = "0.6.0", features = ["sass", "sri", "mime03"] }
 //!
 //! [dependencies]
 //! mime = "0.3.13"
@@ -118,6 +121,8 @@ extern crate mime;
 extern crate nom;
 #[cfg(feature = "sass")]
 extern crate rsass;
+#[cfg(feature = "sri")]
+extern crate ssri;
 
 pub mod Template_syntax;
 mod expression;


### PR DESCRIPTION
 * Add an `sri` feature, which depends on the `ssri` crate
 * Generate sha256, sha384, and sha512 SRI hashes for statics
 * Update examples to use SRI