### PR TITLE
add tide example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
       - cd ../simple && cargo fmt -- --check
       - cd ../static-sass && cargo fmt -- --check
       - cd ../statics && cargo fmt -- --check
+      - cd ../tide && cargo fmt -- --check
       - cd ../warp02 && cargo fmt -- --check
    - rust: stable
      env: EXAMPLE=ed2018

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ matrix:
      env: EXAMPLE=warp02
      script: cd examples/$EXAMPLE && cargo test
    - rust: stable
+     env: EXAMPLE=tide
+     script: cd examples/$EXAMPLE && cargo test
+   - rust: stable
      env: EXAMPLE=gotham
      script: cd examples/$EXAMPLE && cargo test
    - rust: stable

--- a/examples/tide/Cargo.toml
+++ b/examples/tide/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tide"
+version = "0.4.0"
+authors = ["Rasmus Kaj <kaj@kth.se>"]
+edition = "2018"
+
+build = "src/build.rs"
+
+[build-dependencies]
+ructe = { path = "../.." }
+
+[dependencies]
+async-std = { version = "1.6.0", features = ["attributes"] }
+tide = "0.10.0"

--- a/examples/tide/src/build.rs
+++ b/examples/tide/src/build.rs
@@ -1,0 +1,9 @@
+//! This job builds rust source from templates,
+//! which can then be `include!`d in `main.rs`.
+
+use ructe::{Ructe, RucteError};
+
+fn main() -> Result<(), RucteError> {
+    let mut ructe = Ructe::from_env()?;
+    ructe.compile_templates("templates")
+}

--- a/examples/tide/src/main.rs
+++ b/examples/tide/src/main.rs
@@ -1,0 +1,24 @@
+// And finally, include the generated code for templates and static files.
+include!(concat!(env!("OUT_DIR"), "/templates.rs"));
+
+mod ructe_tide;
+use ructe_tide::Render;
+
+use tide::{Response, StatusCode};
+
+#[async_std::main]
+async fn main() -> Result<(), std::io::Error> {
+    let mut app = tide::new();
+
+    app.at("/").get(|_| async {
+        let mut res = Response::new(StatusCode::Ok);
+        res.render_html(|o| Ok(templates::hello(o, "world")?))?;
+        Ok(res)
+    });
+
+    let addr = "127.0.0.1:3000";
+    println!("Starting server on http://{}/", addr);
+    app.listen(addr).await?;
+
+    Ok(())
+}

--- a/examples/tide/src/ructe_tide.rs
+++ b/examples/tide/src/ructe_tide.rs
@@ -1,0 +1,30 @@
+pub trait Render {
+    fn render<Call>(&mut self, call: Call) -> std::io::Result<()>
+    where
+        Call: FnOnce(&mut dyn std::io::Write) -> std::io::Result<()>;
+
+    fn render_html<Call>(&mut self, call: Call) -> std::io::Result<()>
+    where
+        Call: FnOnce(&mut dyn std::io::Write) -> std::io::Result<()>;
+}
+
+impl Render for tide::Response {
+    fn render<Call>(&mut self, call: Call) -> std::io::Result<()>
+    where
+        Call: FnOnce(&mut dyn std::io::Write) -> std::io::Result<()>,
+    {
+        let mut buf = Vec::new();
+        call(&mut buf)?;
+        self.set_body(buf);
+        Ok(())
+    }
+
+    fn render_html<Call>(&mut self, call: Call) -> std::io::Result<()>
+    where
+        Call: FnOnce(&mut dyn std::io::Write) -> std::io::Result<()>,
+    {
+        self.render(call)?;
+        self.set_content_type(tide::http::mime::HTML);
+        Ok(())
+    }
+}

--- a/examples/tide/templates/hello.rs.html
+++ b/examples/tide/templates/hello.rs.html
@@ -1,0 +1,3 @@
+@(msg: &str)
+
+hello @msg


### PR DESCRIPTION
Add [tide](https://github.com/http-rs/tide) example. PR for https://github.com/kaj/ructe/issues/79

In `ructe_tide.rs` I used full qualified namespace so that others can easily copy paste their code in `main.rs` or other projects and is easy to onboard.