### PR TITLE
Try to help incremental compilation be faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ project adheres to
 
 ## Unreleased
 
+* Try to improve incremental compile times of projects using ructe by
+  only writing fils if their contents actually changed. Also some code
+  cleanup. PR #97.
 * Update optional rsass dependency to 0.16.0.
 * Add optional support for tide 0.14 and 0.15.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,15 +230,33 @@ impl Ructe {
     ///
     /// [cargo]: https://doc.rust-lang.org/cargo/
     /// [`from_env`]: #method.from_env
-    pub fn new(out_dir: PathBuf) -> Result<Ructe> {
-        let mut f = File::create(out_dir.join("templates.rs"))?;
-        f.write_all(
-            b"pub mod templates {\n\
-              use std::io::{self, Write};\n\
-              use std::fmt::Display;\n\n",
-        )?;
-        let outdir = out_dir.join("templates");
+    pub fn new(outdir: PathBuf) -> Result<Ructe> {
+        let mut f = File::create(outdir.join("templates.rs"))?;
+        let outdir = outdir.join("templates");
         create_dir_all(&outdir)?;
+        f.write_all(b"pub mod templates {\n")?;
+        {
+            let mut utils = File::create(outdir.join("_utils.rs"))?;
+            utils.write_all(include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/src/templates/utils.rs"
+            )))?;
+        }
+        f.write_all(
+            b"#[doc(hidden)]\nmod _utils;\n\
+                      #[doc(inline)]\npub use self::_utils::*;\n\n",
+        )?;
+        if cfg!(feature = "warp02") {
+            let mut utils = File::create(outdir.join("_utils_warp02.rs"))?;
+            utils.write_all(include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/src/templates/utils_warp02.rs"
+            )))?;
+            f.write_all(
+                b"#[doc(hidden)]\nmod _utils_warp02;\n\
+                          #[doc(inline)]\npub use self::_utils_warp02::*;\n\n",
+            )?;
+        }
         Ok(Ructe { f, outdir })
     }
 
@@ -301,21 +319,7 @@ impl Ructe {
 
 impl Drop for Ructe {
     fn drop(&mut self) {
-        self.f
-            .write_all(include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/src/template_utils.rs"
-            )))
-            .unwrap();
-        if cfg!(feature = "warp02") {
-            self.f
-                .write_all(include_bytes!(concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/src/template_utils_warp02.rs"
-                )))
-                .unwrap();
-        }
-        self.f.write_all(b"\n}\n").unwrap();
+        self.f.write_all(b"}\n").unwrap();
     }
 }
 
@@ -353,7 +357,9 @@ fn handle_entries(
                     if handle_template(&name, &path, outdir)? {
                         writeln!(
                             f,
-                            "mod template_{name};\n\
+                            "#[doc(hidden)]\n\
+                             mod template_{name};\n\
+                             #[doc(inline)]\n\
                              pub use self::template_{name}::{name};\n",
                             name = name,
                         )?;
@@ -363,6 +369,7 @@ fn handle_entries(
                                 f,
                                 "#[deprecated(since=\"0.7.4\", \
                                  note=\"please use `{name}` instead\")]\n\
+                                 #[doc(hidden)]\n\
                                  pub use self::{name} as {alias};\n",
                                 alias = prename,
                                 name = name,
@@ -398,111 +405,7 @@ fn handle_template(
     }
 }
 
-/// The module containing your generated template code will also
-/// contain everything from here.
-///
-/// The name `ructe::templates` should never be used.  Instead, you
-/// should use the module templates created when compiling your
-/// templates.
-/// If you include the generated `templates.rs` in your `main.rs` (or
-/// `lib.rs` in a library crate), this module will be
-/// `crate::templates`.
-pub mod templates {
-    #[cfg(feature = "mime03")]
-    use mime::Mime;
-    use std::fmt::Display;
-    use std::io::{self, Write};
-
-    #[cfg(feature = "mime02")]
-    /// Documentation mock.  The real Mime type comes from the `mime` crate.
-    pub type Mime = u8; // mock
-
-    /// A static file has a name (so its url can be recognized) and the
-    /// actual file contents.
-    ///
-    /// The content-type (mime type) of the file is available as a
-    /// static field when building ructe with the `mime03` feature or
-    /// as the return value of a method when building ructe with the
-    /// `mime02` feature (in `mime` version 0.2.x, a Mime cannot be
-    /// defined as a part of a const static value.
-    pub struct StaticFile {
-        /// The actual static file contents.
-        pub content: &'static [u8],
-        /// The file name as used in a url, including a short (48 bits
-        /// as 8 base64 characters) hash of the content, to enable
-        /// long-time caching of static resourses in the clients.
-        pub name: &'static str,
-        /// The Mime type of this static file, as defined in the mime
-        /// crate version 0.3.x.
-        #[cfg(feature = "mime03")]
-        pub mime: &'static Mime,
-    }
-
-    impl StaticFile {
-        /// Get the mime type of this static file.
-        ///
-        /// Currently, this method parses a (static) string every time.
-        /// A future release of `mime` may support statically created
-        /// `Mime` structs, which will make this nicer.
-        #[allow(unused)]
-        #[cfg(feature = "mime02")]
-        pub fn mime(&self) -> Mime {
-            unimplemented!()
-        }
-    }
-
-    include!("template_utils.rs");
-
-    #[test]
-    fn encoded() {
-        let mut buf = Vec::new();
-        "a < b\0\n".to_html(&mut buf).unwrap();
-        assert_eq!(b"a &lt; b\0\n", &buf[..]);
-
-        let mut buf = Vec::new();
-        "'b".to_html(&mut buf).unwrap();
-        assert_eq!(b"&#39;b", &buf[..]);
-
-        let mut buf = Vec::new();
-        "xxxxx>&".to_html(&mut buf).unwrap();
-        assert_eq!(b"xxxxx&gt;&amp;", &buf[..]);
-    }
-
-    #[test]
-    fn encoded_empty() {
-        let mut buf = Vec::new();
-        "".to_html(&mut buf).unwrap();
-        "".to_html(&mut buf).unwrap();
-        "".to_html(&mut buf).unwrap();
-        assert_eq!(b"", &buf[..]);
-    }
-
-    #[test]
-    fn double_encoded() {
-        let mut buf = Vec::new();
-        "&amp;".to_html(&mut buf).unwrap();
-        "&lt;".to_html(&mut buf).unwrap();
-        assert_eq!(b"&amp;amp;&amp;lt;", &buf[..]);
-    }
-
-    #[test]
-    fn encoded_only() {
-        let mut buf = Vec::new();
-        "&&&&&&&&&&&&&&&&".to_html(&mut buf).unwrap();
-        assert_eq!(b"&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;" as &[u8], &buf[..]);
-
-        let mut buf = Vec::new();
-        "''''''''''''''".to_html(&mut buf).unwrap();
-        assert_eq!(b"&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;" as &[u8], &buf[..]);
-    }
-
-    #[test]
-    fn raw_html() {
-        let mut buf = Vec::new();
-        Html("a<b>c</b>").to_html(&mut buf).unwrap();
-        assert_eq!(b"a<b>c</b>", &buf[..]);
-    }
-}
+pub mod templates;
 
 fn get_env(name: &str) -> Result<String> {
     env::var(name).map_err(|e| RucteError::Env(name.into(), e))

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -1,0 +1,103 @@
+//! The module containing your generated template code will also
+//! contain everything from here.
+//!
+//! The name `ructe::templates` should never be used.  Instead, you
+//! should use the module templates created when compiling your
+//! templates.
+//! If you include the generated `templates.rs` in your `main.rs` (or
+//! `lib.rs` in a library crate), this module will be
+//! `crate::templates`.
+
+mod utils;
+pub use self::utils::*;
+
+#[cfg(feature = "mime03")]
+use mime::Mime;
+
+#[cfg(feature = "mime02")]
+/// Documentation mock.  The real Mime type comes from the `mime` crate.
+pub type Mime = u8; // mock
+
+/// A static file has a name (so its url can be recognized) and the
+/// actual file contents.
+///
+/// The content-type (mime type) of the file is available as a
+/// static field when building ructe with the `mime03` feature or
+/// as the return value of a method when building ructe with the
+/// `mime02` feature (in `mime` version 0.2.x, a Mime cannot be
+/// defined as a part of a const static value.
+pub struct StaticFile {
+    /// The actual static file contents.
+    pub content: &'static [u8],
+    /// The file name as used in a url, including a short (48 bits
+    /// as 8 base64 characters) hash of the content, to enable
+    /// long-time caching of static resourses in the clients.
+    pub name: &'static str,
+    /// The Mime type of this static file, as defined in the mime
+    /// crate version 0.3.x.
+    #[cfg(feature = "mime03")]
+    pub mime: &'static Mime,
+}
+
+impl StaticFile {
+    /// Get the mime type of this static file.
+    ///
+    /// Currently, this method parses a (static) string every time.
+    /// A future release of `mime` may support statically created
+    /// `Mime` structs, which will make this nicer.
+    #[allow(unused)]
+    #[cfg(feature = "mime02")]
+    pub fn mime(&self) -> Mime {
+        unimplemented!()
+    }
+}
+
+#[test]
+fn encoded() {
+    let mut buf = Vec::new();
+    "a < b\0\n".to_html(&mut buf).unwrap();
+    assert_eq!(b"a &lt; b\0\n", &buf[..]);
+
+    let mut buf = Vec::new();
+    "'b".to_html(&mut buf).unwrap();
+    assert_eq!(b"&#39;b", &buf[..]);
+
+    let mut buf = Vec::new();
+    "xxxxx>&".to_html(&mut buf).unwrap();
+    assert_eq!(b"xxxxx&gt;&amp;", &buf[..]);
+}
+
+#[test]
+fn encoded_empty() {
+    let mut buf = Vec::new();
+    "".to_html(&mut buf).unwrap();
+    "".to_html(&mut buf).unwrap();
+    "".to_html(&mut buf).unwrap();
+    assert_eq!(b"", &buf[..]);
+}
+
+#[test]
+fn double_encoded() {
+    let mut buf = Vec::new();
+    "&amp;".to_html(&mut buf).unwrap();
+    "&lt;".to_html(&mut buf).unwrap();
+    assert_eq!(b"&amp;amp;&amp;lt;", &buf[..]);
+}
+
+#[test]
+fn encoded_only() {
+    let mut buf = Vec::new();
+    "&&&&&&&&&&&&&&&&".to_html(&mut buf).unwrap();
+    assert_eq!(b"&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;" as &[u8], &buf[..]);
+
+    let mut buf = Vec::new();
+    "''''''''''''''".to_html(&mut buf).unwrap();
+    assert_eq!(b"&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;&#39;" as &[u8], &buf[..]);
+}
+
+#[test]
+fn raw_html() {
+    let mut buf = Vec::new();
+    Html("a<b>c</b>").to_html(&mut buf).unwrap();
+    assert_eq!(b"a<b>c</b>", &buf[..]);
+}

--- a/src/templates/utils.rs
+++ b/src/templates/utils.rs
@@ -1,3 +1,6 @@
+use std::fmt::Display;
+use std::io::{self, Write};
+
 /// This trait should be implemented for any value that can be the
 /// result of an expression in a template.
 ///

--- a/src/templates/utils_warp02.rs
+++ b/src/templates/utils_warp02.rs
@@ -1,4 +1,5 @@
 use mime::TEXT_HTML_UTF_8;
+use std::io;
 use warp::http::{header::CONTENT_TYPE, response::Builder};
 use warp::{reject::custom, reject::Reject, reply::Response, Rejection};
 


### PR DESCRIPTION
Try to make incremental compilation faster by writing generated source files only when their contents actually changes.

The code that is made available in the templates module of projects using ructe is moved into the templates module of ructe. Also, the files containing that code is now handled as proper submodules, both in ructe itself and in generated code.
