### PR TITLE
fix not being able to use Html<T: Display> in templates

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -32,7 +32,7 @@ impl Template {
              #[cfg_attr(feature=\"cargo-clippy\", \
              allow(useless_attribute))]\n\
              #[allow(unused)]\n\
-             use super::{Html,ToHtml};\n",
+             use ructe::templates::{Html,ToHtml};\n",
         )?;
         for l in &self.preamble {
             writeln!(out, "{};", l)?;


### PR DESCRIPTION
Using `Html<T: Display>` (theoretically) allows printing raw strings without encoding into a template, so it could be used to work around #1. During trying this out, I encountered following error:
```
   |
10 | helper().to_html(&mut _ructe_out_)?;
   |          ^^^^^^^ method cannot be called on `ructe::templates::Html<String>` due to unsatisfied trait bounds
   |
  ::: /home/jojii/.cargo/registry/src/github.com-1ecc6299db9ec823/ructe-0.13.4/src/templates/utils.rs:78:1
   |
78 | pub struct Html<T>(pub T);
   | --------------------------
   | |
   | doesn't satisfy `ructe::templates::Html<String>: _utils::ToHtml`
   | doesn't satisfy `ructe::templates::Html<String>: std::fmt::Display`
   |
   = note: the following trait bounds were not satisfied:
           `ructe::templates::Html<String>: std::fmt::Display`
           which is required by `ructe::templates::Html<String>: _utils::ToHtml`
   = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
   |
1  | use ructe::templates::ToHtml;
   |
```

By replacing the relative import path in the templates preamble with the absolute module path fixes this issue and one can successfully work around #1 
<br>
**Note:** I haven't looked through all of ructes code so I can't assure they are semantically equivalent