### PR TITLE
Fix clippy lint `clippy::get-first`

### DIFF
--- a/src/templates/utils.rs
+++ b/src/templates/utils.rs
@@ -125,7 +125,7 @@ impl<'a> ToHtmlEscapingWriter<'a> {
         out: &mut impl Write,
         data: &[u8],
     ) -> io::Result<usize> {
-        let next = data.get(0);
+        let next = data.first();
         out.write_all(match next {
             Some(b'"') => b"&quot;",
             Some(b'&') => b"&amp;",


### PR DESCRIPTION
A new clippy lint fails on `slice.get(0)` and proposes to use `slice.first()` instead. Here is an example of a failing build: https://github.com/vbrandl/hoc/runs/7832070989?check_suite_focus=true

And here is the lint in question: https://rust-lang.github.io/rust-clippy/master/index.html#get_first