### PR TITLE
Support chaining in StaticFiles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on
 project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+* Breaking change: Most methods of `StaticFiles` now supports method
+  chaining, by returning `Result<&mut Self>`, making typical build scripts
+  nicer (PR #115).
+
+
 ## Release 0.14.2 - 2022-08-20
 
 * Improve error reporting.  The debug output for `RucteError` is now the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ructe"
-version = "0.14.2"
+version = "0.15.0-PRE"
 authors = ["Rasmus Kaj <kaj@kth.se>"]
 description = "Rust Compiled Templates, efficient type-safe web page templates."
 documentation = "https://docs.rs/ructe"

--- a/examples/actix/src/build.rs
+++ b/examples/actix/src/build.rs
@@ -4,8 +4,9 @@ use ructe::{Ructe, RucteError};
 
 fn main() -> Result<(), RucteError> {
     let mut ructe = Ructe::from_env()?;
-    let mut statics = ructe.statics()?;
-    statics.add_files("statics")?;
-    statics.add_sass_file("style.scss")?;
+    ructe
+        .statics()?
+        .add_files("statics")?
+        .add_sass_file("style.scss")?;
     ructe.compile_templates("templates")
 }

--- a/examples/gotham/src/build.rs
+++ b/examples/gotham/src/build.rs
@@ -4,8 +4,9 @@ use ructe::{Result, Ructe};
 
 fn main() -> Result<()> {
     let mut ructe = Ructe::from_env()?;
-    let mut statics = ructe.statics()?;
-    statics.add_files("statics")?;
-    statics.add_sass_file("style.scss")?;
+    ructe
+        .statics()?
+        .add_files("statics")?
+        .add_sass_file("style.scss")?;
     ructe.compile_templates("templates")
 }

--- a/examples/iron/src/build.rs
+++ b/examples/iron/src/build.rs
@@ -5,8 +5,9 @@ use ructe::{Result, Ructe};
 
 fn main() -> Result<()> {
     let mut ructe = Ructe::from_env()?;
-    let mut statics = ructe.statics()?;
-    statics.add_files("statics")?;
-    statics.add_sass_file("style.scss")?;
+    ructe
+        .statics()?
+        .add_files("statics")?
+        .add_sass_file("style.scss")?;
     ructe.compile_templates("templates")
 }

--- a/examples/nickel/src/build.rs
+++ b/examples/nickel/src/build.rs
@@ -6,8 +6,9 @@ use ructe::{Result, Ructe};
 
 fn main() -> Result<()> {
     let mut ructe = Ructe::from_env()?;
-    let mut statics = ructe.statics()?;
-    statics.add_files("statics")?;
-    statics.add_sass_file("style.scss")?;
+    ructe
+        .statics()?
+        .add_files("statics")?
+        .add_sass_file("style.scss")?;
     ructe.compile_templates("templates")
 }

--- a/examples/static-sass/src/build.rs
+++ b/examples/static-sass/src/build.rs
@@ -2,9 +2,9 @@ use ructe::{Ructe, RucteError};
 
 fn main() -> Result<(), RucteError> {
     let mut ructe = Ructe::from_env()?;
-    let mut statics = ructe.statics()?;
-    statics.add_files("static")?;
-    statics.add_sass_file("scss/style.scss")?;
-
+    ructe
+        .statics()?
+        .add_files("static")?
+        .add_sass_file("scss/style.scss")?;
     ructe.compile_templates("templates")
 }

--- a/examples/tide/src/build.rs
+++ b/examples/tide/src/build.rs
@@ -5,8 +5,9 @@ use ructe::{Ructe, RucteError};
 
 fn main() -> Result<(), RucteError> {
     let mut ructe = Ructe::from_env()?;
-    let mut statics = ructe.statics()?;
-    statics.add_files("statics")?;
-    statics.add_sass_file("style.scss")?;
+    ructe
+        .statics()?
+        .add_files("statics")?
+        .add_sass_file("style.scss")?;
     ructe.compile_templates("templates")
 }

--- a/examples/warp03/src/build.rs
+++ b/examples/warp03/src/build.rs
@@ -4,8 +4,9 @@ use ructe::{Ructe, RucteError};
 
 fn main() -> Result<(), RucteError> {
     let mut ructe = Ructe::from_env()?;
-    let mut statics = ructe.statics()?;
-    statics.add_files("statics")?;
-    statics.add_sass_file("style.scss")?;
+    ructe
+        .statics()?
+        .add_files("statics")?
+        .add_sass_file("style.scss")?;
     ructe.compile_templates("templates")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,7 +299,8 @@ impl Ructe {
     /// # use ructe::{Ructe, RucteError};
     /// # fn main() -> Result<(), RucteError> {
     /// let mut ructe = Ructe::from_env()?;
-    /// ructe.statics()?.add_files("static")
+    /// ructe.statics()?.add_files("static")?;
+    /// Ok(())
     /// # }
     /// ```
     ///


### PR DESCRIPTION
Make most methods of `StaticFiles` return `Result<&mut Self>`, to support method chaining, making typical build scripts nicer.