### PR TITLE
Prepare for rsass 0.26.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,8 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.52.1
-          - 1.48.0
-          - 1.46.0
+          - 1.60.0
+          - 1.56.1
           - beta
           - nightly
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ itertools = "0.10.0"
 md5 = "0.7"
 nom = "7.1.0"
 
-rsass = { git = "https://github.com/kaj/rsass", optional = true }
+rsass = { version = "0.26.0", optional = true }
 mime = { version = "0.3", optional = true }
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ itertools = "0.10.0"
 md5 = "0.7"
 nom = "7.1.0"
 
-rsass = { version = "0.25.0", optional = true }
+rsass = { git = "https://github.com/kaj/rsass", optional = true }
 mime = { version = "0.3", optional = true }
 
 [badges]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,17 +456,17 @@ impl Error for RucteError {
 
 impl Display for RucteError {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            RucteError::Io(err) => Display::fmt(err, out),
-            RucteError::Env(var, err) => write!(out, "{:?}: {}", var, err),
-            #[cfg(feature = "sass")]
-            RucteError::Sass(err) => Display::fmt(err, out),
-        }
+        write!(out, "Error: {:?}", self)
     }
 }
 impl Debug for RucteError {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
-        Display::fmt(self, out)
+        match self {
+            RucteError::Io(err) => Display::fmt(err, out),
+            RucteError::Env(var, err) => write!(out, "{:?}: {}", var, err),
+            #[cfg(feature = "sass")]
+            RucteError::Sass(err) => Debug::fmt(err, out),
+        }
     }
 }
 


### PR DESCRIPTION
- [x] MRSV is now 1.56.1.
- [x] Proper dependency tracking for scss files
- [x] Nicer argument handling in builtin sass function.
- [x] Await the actual release of rsass 0.26.