### PR TITLE
Take writer by value

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -41,7 +41,7 @@ impl Template {
         writeln!(
             out,
             "\n\
-             pub fn {name}<{ta}{ta_sep}W>(_ructe_out_: &mut W{args}) -> io::Result<()>\n\
+             pub fn {name}<{ta}{ta_sep}W>(#[allow(unused_mut)] mut _ructe_out_: W{args}) -> io::Result<()>\n\
              where W: Write {{\n\
              {body}\
              Ok(())\n\

--- a/src/templateexpression.rs
+++ b/src/templateexpression.rs
@@ -82,7 +82,7 @@ impl TemplateExpression {
                 format!("_ructe_out_.write_all({text:?}.as_bytes())?;\n")
             }
             TemplateExpression::Expression { ref expr } => {
-                format!("{expr}.to_html(_ructe_out_)?;\n")
+                format!("{expr}.to_html(_ructe_out_.by_ref())?;\n")
             }
             TemplateExpression::ForLoop {
                 ref name,
@@ -122,7 +122,7 @@ impl TemplateExpression {
             ),
             TemplateExpression::CallTemplate { ref name, ref args } => {
                 format!(
-                    "{name}(_ructe_out_{})?;\n",
+                    "{name}(_ructe_out_.by_ref(){})?;\n",
                     args.iter().format_with("", |arg, f| f(&format_args!(
                         ", {arg}"
                     ))),


### PR DESCRIPTION
`io::Write` is implemented for all `&mut io::Write`, so the `&mut` part doesn't have to be explicit.

Fixes #111