### PR TITLE
Fix or suppress pedantic clippy warnings

### DIFF
--- a/src/staticfiles.rs
+++ b/src/staticfiles.rs
@@ -238,6 +238,7 @@ pub struct StaticFile {
 #[allow(dead_code)]
 impl StaticFile {
     /// Get a single `StaticFile` by name, if it exists.
+    #[must_use]
     pub fn get(name: &str) -> Option<&'static Self> {
         if let Ok(pos) = STATICS.binary_search_by_key(&name, |s| s.name) {
             Some(STATICS[pos])

--- a/src/template.rs
+++ b/src/template.rs
@@ -41,6 +41,7 @@ impl Template {
         writeln!(
             out,
             "\n\
+             #[allow(clippy::used_underscore_binding)]\n\
              pub fn {name}<{ta}{ta_sep}W>(_ructe_out_: &mut W{args}) -> io::Result<()>\n\
              where W: Write {{\n\
              {body}\

--- a/src/template.rs
+++ b/src/template.rs
@@ -41,7 +41,8 @@ impl Template {
         writeln!(
             out,
             "\n\
-             pub fn {name}<{ta}{ta_sep}W>(#[allow(unused_mut, clippy::used_underscore_binding)] mut _ructe_out_: W{args}) -> io::Result<()>\n\
+             #[allow(clippy::used_underscore_binding)]\n
+             pub fn {name}<{ta}{ta_sep}W>(#[allow(unused_mut)] mut _ructe_out_: W{args}) -> io::Result<()>\n\
              where W: Write {{\n\
              {body}\
              Ok(())\n\

--- a/src/templateexpression.rs
+++ b/src/templateexpression.rs
@@ -59,7 +59,7 @@ impl Display for TemplateArgument {
             }
             TemplateArgument::Body(ref v) => writeln!(
                 out,
-                "|mut _ructe_out_| {{\n{}\nOk(())\n}}",
+                "#[allow(clippy::used_underscore_binding)] |mut _ructe_out_| {{\n{}\nOk(())\n}}",
                 v.iter().map(|b| b.code()).format(""),
             ),
         }


### PR DESCRIPTION
Two lints will fail if `clippy::pedantic` is enabled:

1.
```
error: used binding `_ructe_out_` which is prefixed with an underscore. A leading underscore signals that a binding will not be used
```

   After the discussion in https://github.com/kaj/ructe/issues/126, I opted for `#[allow(clippy::used_underscore_binding)]` where `_ructe_out_` is defined, as to not break any existing code

2.  
```
error: this method could have a `#[must_use]` attribute
  --> <snip>/out/templates/statics.rs:18:5
   |
18 |     pub fn get(name: &str) -> Option<&'static Self> {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn get(name: &str) -> Option<&'static Self>`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate
   = note: `-D clippy::must-use-candidate` implied by `-D clippy::pedantic`
```


    this is fixed by adding the `#[must_use]` attribute to the generated code



Fixes https://github.com/kaj/ructe/issues/126