### PR TITLE
Handle bad file names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ project adheres to
   Thanks @kornelski!
 * Fixed handling of `MULTI_WORD_CONSTANTS` in templates (Issue #129, PR #130).
   Thanks @wezm!
+* More ways to create a working rust symbol name from a "strange"
+  static file name.  Illegal characters are replaced by `_`, and if
+  the file name starts with a number it is prefixed with `n` (Issue
+  #82, PR #132).  Thanks @Aedius for reporting!
 * Fixed more clippy lints (PR #123, #127).  Thanks @vbrandl!
 * Updated `rsass` to 0.28.0 and `itertools` to 0.11.0.
 

--- a/examples/statics/src/main.rs
+++ b/examples/statics/src/main.rs
@@ -59,8 +59,22 @@ fn test_all_statics_known() {
     use templates::statics::STATICS;
     assert_eq!(
         STATICS.iter().map(|s| s.name).collect::<Vec<_>>(),
-        ["foo-JckCHvyv.css", "foo-R-7hhHLr.js", "style-o2rFo1lI.css"]
+        [
+            "17-C0lZWdZX.css",
+            "foo-JckCHvyv.css",
+            "foo-R-7hhHLr.js",
+            "style-o2rFo1lI.css"
+        ]
     );
+}
+
+/// Test for issue #82.
+#[test]
+fn test_num_gets_prefixed() {
+    // The rust name is usable in rust.
+    let style = &templates::statics::n17_css;
+    // Url name is not prefixed (but has a content hash).
+    assert_eq!(style.name, "17-C0lZWdZX.css");
 }
 
 #[cfg(test)]

--- a/examples/statics/static/17.css
+++ b/examples/statics/static/17.css
@@ -1,0 +1,1 @@
+body { font-family: serif; }

--- a/src/staticfiles.rs
+++ b/src/staticfiles.rs
@@ -517,7 +517,16 @@ impl StaticFile {
         content: &impl Display,
         suffix: &str,
     ) -> Result<&mut Self> {
-        let rust_name = rust_name.replace(['/', '-', '.'], "_");
+        let mut rust_name =
+            rust_name.replace(|c: char| !c.is_alphanumeric(), "_");
+        if rust_name
+            .as_bytes()
+            .first()
+            .map(|c| c.is_ascii_digit())
+            .unwrap_or(true)
+        {
+            rust_name.insert(0, 'n');
+        }
         writeln!(
             self.src,
             "\n/// From {path:?}\


### PR DESCRIPTION
More ways to create a working rust symbol name from a "strange" static file name.  Illegal characters are replaced by `_`, and if the file name starts with a number it is prefixed with `n`.

Fixes #82 .