### PR TITLE
Fix clippy lints

### DIFF
--- a/src/templates/utils.rs
+++ b/src/templates/utils.rs
@@ -93,7 +93,7 @@ impl<T: Display> ToHtml for T {
 
 struct ToHtmlEscapingWriter<'a>(&'a mut dyn Write);
 
-impl<'a> Write for ToHtmlEscapingWriter<'a> {
+impl Write for ToHtmlEscapingWriter<'_> {
     #[inline]
     // This takes advantage of the fact that `write` doesn't have to write everything,
     // and the call will be retried with the rest of the data
@@ -119,7 +119,7 @@ impl<'a> Write for ToHtmlEscapingWriter<'a> {
     }
 }
 
-impl<'a> ToHtmlEscapingWriter<'a> {
+impl ToHtmlEscapingWriter<'_> {
     #[inline(never)]
     fn write_one_byte_escaped(
         out: &mut impl Write,


### PR DESCRIPTION
Once again I'm asking you for your support to fix clippy lints :D
So here we go again.

I have the following pipeline which fails with a clippy lint: https://github.com/vbrandl/hoc/actions/runs/12082520261/job/33693766298?pr=861#step:5:254

I think these changes should fix the lint.

I also know that you are not really have time to maintain this repository but it would be nice to keep the clippy lints fixed.