### PR TITLE
Update `nom` to 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           - stable
           - 1.75.0
           - 1.67.1
-          - 1.63.0
+          - 1.65.0
           - beta
           - nightly
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ project adheres to
 
 ## Unreleased
 
-(Nothing yet)
+* Updated `nom` to 8.0.0, and added `nom-language`.
+* MSRV is now 1.65.0, as required by `nom` 8.0.
 
 
 ## Release 0.18.0 -- 2025-02-03

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["web", "templating", "template", "html"]
 categories = ["template-engine", "web-programming"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.63.0"
+rust-version = "1.65.0"
 
 [features]
 sass = ["dep:rsass"]
@@ -27,7 +27,8 @@ base64 = "0.22.1"
 bytecount = "0.6.0"
 itertools = "0.14.0"
 md5 = "0.7"
-nom = "7.1.0"
+nom = "8.0.0"
+nom-language = "0.1.0"
 
 rsass = { version = "0.29.0", optional = true }
 mime = { version = "0.3", optional = true }

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -158,12 +158,12 @@ mod models {
         pub name: &'a str,
         pub email: &'a str,
     }
-    impl<'a> User<'a> {
+    impl User<'_> {
         pub fn mailto(&self) -> Html<String> {
             Html(format!("<a href=\"mailto:{0}\">{0}</a>", self.email))
         }
     }
-    impl<'a> fmt::Display for User<'a> {
+    impl fmt::Display for User<'_> {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             f.write_str(self.name)
         }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -3,16 +3,17 @@ use nom::branch::alt;
 use nom::bytes::complete::{escaped, is_a, is_not, tag};
 use nom::character::complete::{alpha1, char, digit1, none_of, one_of};
 use nom::combinator::{map, map_res, not, opt, recognize, value};
-use nom::error::context; //, VerboseError};
+use nom::error::context;
 use nom::multi::{fold_many0, many0, separated_list0};
-use nom::sequence::{delimited, pair, preceded, terminated, tuple};
+use nom::sequence::{delimited, pair, preceded, terminated};
+use nom::Parser as _;
 use std::str::{from_utf8, Utf8Error};
 
 pub fn expression(input: &[u8]) -> PResult<&str> {
     map_res(
         recognize(context(
             "Expected rust expression",
-            tuple((
+            (
                 map_res(alt((tag("&"), tag("*"), tag(""))), input_to_str),
                 alt((
                     rust_name,
@@ -34,10 +35,11 @@ pub fn expression(input: &[u8]) -> PResult<&str> {
                     || (),
                     |_, _| (),
                 ),
-            )),
+            ),
         )),
         input_to_str,
-    )(input)
+    )
+    .parse(input)
 }
 
 pub fn input_to_str(s: &[u8]) -> Result<&str, Utf8Error> {
@@ -48,7 +50,8 @@ pub fn comma_expressions(input: &[u8]) -> PResult<String> {
     map(
         separated_list0(preceded(tag(","), many0(tag(" "))), expression),
         |list: Vec<_>| list.join(", "),
-    )(input)
+    )
+    .parse(input)
 }
 
 pub fn rust_name(input: &[u8]) -> PResult<&str> {
@@ -58,14 +61,15 @@ pub fn rust_name(input: &[u8]) -> PResult<&str> {
             opt(is_a("_0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")),
         )),
         input_to_str,
-    )(input)
+    ).parse(input)
 }
 
 fn expr_in_parens(input: &[u8]) -> PResult<&str> {
     map_res(
         recognize(delimited(tag("("), expr_inside_parens, tag(")"))),
         input_to_str,
-    )(input)
+    )
+    .parse(input)
 }
 
 fn expr_in_brackets(input: &[u8]) -> PResult<&str> {
@@ -84,7 +88,8 @@ fn expr_in_brackets(input: &[u8]) -> PResult<&str> {
             tag("]"),
         )),
         input_to_str,
-    )(input)
+    )
+    .parse(input)
 }
 
 pub fn expr_in_braces(input: &[u8]) -> PResult<&str> {
@@ -103,7 +108,8 @@ pub fn expr_in_braces(input: &[u8]) -> PResult<&str> {
             tag("}"),
         )),
         input_to_str,
-    )(input)
+    )
+    .parse(input)
 }
 
 pub fn expr_inside_parens(input: &[u8]) -> PResult<&str> {
@@ -118,7 +124,8 @@ pub fn expr_inside_parens(input: &[u8]) -> PResult<&str> {
             value((), terminated(tag("/"), none_of("*"))),
         )))),
         input_to_str,
-    )(input)
+    )
+    .parse(input)
 }
 
 pub fn quoted_string(input: &[u8]) -> PResult<&str> {
@@ -129,7 +136,8 @@ pub fn quoted_string(input: &[u8]) -> PResult<&str> {
             char('"'),
         )),
         input_to_str,
-    )(input)
+    )
+    .parse(input)
 }
 
 pub fn rust_comment(input: &[u8]) -> PResult<&[u8]> {
@@ -140,7 +148,8 @@ pub fn rust_comment(input: &[u8]) -> PResult<&[u8]> {
             terminated(tag("*"), not(tag("/"))),
         )))),
         tag("*/"),
-    )(input)
+    )
+    .parse(input)
 }
 
 #[cfg(test)]

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -14,7 +14,7 @@ pub fn expression(input: &[u8]) -> PResult<&str> {
         recognize(context(
             "Expected rust expression",
             (
-                map_res(alt((tag("&"), tag("*"), tag(""))), input_to_str),
+                alt((tag("&"), tag("*"), tag(""))),
                 alt((
                     rust_name,
                     map_res(digit1, input_to_str),

--- a/src/parseresult.rs
+++ b/src/parseresult.rs
@@ -1,5 +1,5 @@
-use nom::error::{VerboseError, VerboseErrorKind};
 use nom::{Err, IResult};
+use nom_language::error::{VerboseError, VerboseErrorKind};
 use std::io::Write;
 use std::str::from_utf8;
 

--- a/src/spacelike.rs
+++ b/src/spacelike.rs
@@ -2,13 +2,13 @@ use crate::parseresult::PResult;
 use nom::branch::alt;
 use nom::bytes::complete::{is_not, tag};
 use nom::character::complete::{multispace1, none_of};
-use nom::combinator::{map, value};
+use nom::combinator::value;
 use nom::multi::many0;
 use nom::sequence::preceded;
 use nom::Parser as _;
 
 pub fn spacelike(input: &[u8]) -> PResult<()> {
-    map(many0(alt((comment, map(multispace1, |_| ())))), |_| ()).parse(input)
+    value((), many0(alt((comment, value((), multispace1))))).parse(input)
 }
 
 pub fn comment(input: &[u8]) -> PResult<()> {

--- a/src/spacelike.rs
+++ b/src/spacelike.rs
@@ -5,13 +5,14 @@ use nom::character::complete::{multispace1, none_of};
 use nom::combinator::{map, value};
 use nom::multi::many0;
 use nom::sequence::preceded;
+use nom::Parser as _;
 
 pub fn spacelike(input: &[u8]) -> PResult<()> {
-    map(many0(alt((comment, map(multispace1, |_| ())))), |_| ())(input)
+    map(many0(alt((comment, map(multispace1, |_| ())))), |_| ()).parse(input)
 }
 
 pub fn comment(input: &[u8]) -> PResult<()> {
-    preceded(tag("@*"), comment_tail)(input)
+    preceded(tag("@*"), comment_tail).parse(input)
 }
 
 pub fn comment_tail(input: &[u8]) -> PResult<()> {
@@ -21,14 +22,15 @@ pub fn comment_tail(input: &[u8]) -> PResult<()> {
             value((), preceded(tag("*"), none_of("@"))),
         ))),
         value((), tag("*@")),
-    )(input)
+    )
+    .parse(input)
 }
 
 #[cfg(test)]
 mod test {
     use super::{comment, spacelike};
-    use nom::error::{ErrorKind, VerboseError, VerboseErrorKind};
-    use nom::Err;
+    use nom::{error::ErrorKind, Err};
+    use nom_language::error::{VerboseError, VerboseErrorKind};
 
     #[test]
     fn comment1() {

--- a/src/staticfiles.rs
+++ b/src/staticfiles.rs
@@ -429,7 +429,7 @@ impl StaticFile {
                 FormalArgs::new(vec![("name".into(), None)]),
                 Arc::new(move |s| {
                     let name: String = s.get("name".into())?;
-                    let rname = name.replace('-', "_").replace('.', "_");
+                    let rname = name.replace(['-', '.'], "_");
                     existing_statics
                         .iter()
                         .find(|(n, _v)| *n == &rname)
@@ -446,7 +446,7 @@ impl StaticFile {
         );
 
         let css = context.transform(scss)?;
-        self.add_file_data(&src.with_extension("css"), &css)
+        self.add_file_data(src.with_extension("css"), &css)
     }
 
     fn add_static(


### PR DESCRIPTION
* Updated `nom` to 8.0.0, and added `nom-language`.
* MSRV is now 1.65.0, as required by `nom` 8.0.
